### PR TITLE
fix: resolve streamlit imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bash setup.sh
 2. Inicie a interface Streamlit:
 
 ```bash
-streamlit run presentation/streamlit_app.py
+PYTHONPATH=$(pwd) streamlit run presentation/streamlit_app.py
 ```
 
 ## Testes e qualidade de código

--- a/presentation/streamlit_app.py
+++ b/presentation/streamlit_app.py
@@ -1,9 +1,19 @@
 """Streamlit application to visualize maintenance indicators."""
+# ruff: noqa: E402
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import List
 
 import streamlit as st
+
+# Ensure the repository root is in ``sys.path`` when running via ``streamlit``
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
 
 from application.metrics import count_orders, orders_by_priority, percentage
 from infrastructure.csv_repository import OrderServiceCSVRepository

--- a/setup.sh
+++ b/setup.sh
@@ -5,4 +5,7 @@ echo "Instalando dependências..."
 python -m pip install --upgrade pip
 pip install pandas streamlit
 
+echo "Configurando PYTHONPATH..."
+export PYTHONPATH="$PYTHONPATH:$(pwd)"
+
 echo "Setup concluído!"


### PR DESCRIPTION
## Contexto
O app Streamlit falhava ao iniciar por não localizar o pacote `application`.

## Mudanças
- inclui ajuste em `sys.path` no `streamlit_app.py`
- define `PYTHONPATH` no `setup.sh`
- atualiza README com comando de inicialização

## Como testar
- `ruff check . && ruff format .`
- `pytest -q`
- *(Opcional)* `PYTHONPATH=$(pwd) streamlit run presentation/streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_685c0015b2ec832c98ea58966ac1be3b