### PR TITLE
fix/xls-repository-excel-read

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Clone o repositório e execute:
 bash setup.sh
 ```
 
+Este script instalará as dependências listadas em ``requirements.txt``.
+
 ## Execução da aplicação
 
-1. Coloque o arquivo `ordens_servico.xls` em uma pasta `data/` na raiz do projeto. O formato esperado pode ser visto em `tests/fixtures/sample_orders.xls`.
+1. Coloque o arquivo `ordens_servico.xlsx` em uma pasta `data/` na raiz do projeto. O formato esperado pode ser visto em `tests/fixtures/sample_orders.xlsx`.
 2. Inicie a interface Streamlit:
 
 ```bash

--- a/infrastructure/xls_repository.py
+++ b/infrastructure/xls_repository.py
@@ -1,13 +1,8 @@
-"""Repository to load order services from an XLS file.
-
-The expected format is a text-based spreadsheet exported from Excel using comma
-separated values. The file may use the ``.xls`` extension even though it is not
-an actual binary Excel file.
-"""
+"""Repository to load order services from an Excel file."""
 
 from __future__ import annotations
 
-import csv
+import pandas as pd
 from pathlib import Path
 from typing import List
 
@@ -15,7 +10,7 @@ from domain.entities import OrderService
 
 
 class OrderServiceXLSRepository:
-    """Load :class:`OrderService` entries from a pseudo-XLS file."""
+    """Load :class:`OrderService` entries from an Excel file."""
 
     def __init__(self, file_path: Path) -> None:
         """Initialize repository.
@@ -26,25 +21,23 @@ class OrderServiceXLSRepository:
         self._file_path = file_path
 
     def load(self) -> List[OrderService]:
-        """Return all orders from the XLS file.
+        """Return all orders from the Excel file.
 
         Returns:
             Lista de :class:`OrderService` carregadas do arquivo.
         """
-        orders: List[OrderService] = []
-        with self._file_path.open(newline="", encoding="utf-8") as fp:
-            reader = csv.DictReader(fp)
-            for row in reader:
-                orders.append(
-                    OrderService(
-                        tipo_servico=row.get("TIPO SERVI\xc7O", ""),
-                        estado=row.get("ESTADO", ""),
-                        quadro_trabalho=row.get("QUADRO DE TRABALHO", ""),
-                        prioridade=row.get("PRIORIDADE", ""),
-                        estado_tempo_atendimento=row.get(
-                            "Estado tempo atendimento", ""
-                        ),
-                        estado_tempo_fechamento=row.get("Estado tempo fechamento", ""),
-                    )
+        df = pd.read_excel(self._file_path, engine="openpyxl")
+        df = df.where(pd.notnull(df), None)
+        orders = []
+        for row in df.to_dict(orient="records"):
+            orders.append(
+                OrderService(
+                    tipo_servico=row.get("TIPO SERVIÇO", ""),
+                    estado=row.get("ESTADO", ""),
+                    quadro_trabalho=row.get("QUADRO DE TRABALHO", ""),
+                    prioridade=row.get("PRIORIDADE", ""),
+                    estado_tempo_atendimento=row.get("Estado tempo atendimento"),
+                    estado_tempo_fechamento=row.get("Estado tempo fechamento"),
                 )
+            )
         return orders

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+openpyxl
+streamlit

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 echo "Instalando dependências..."
 python -m pip install --upgrade pip
-pip install pandas streamlit
+pip install -r requirements.txt
 
 echo "Configurando PYTHONPATH..."
 export PYTHONPATH="$PYTHONPATH:$(pwd)"


### PR DESCRIPTION
## Contexto
Substitui a leitura de planilhas em `OrderServiceXLSRepository` para usar `pandas` com `openpyxl`.
Também foram adicionadas dependências e atualizado o script de setup e README.

## Mudanças
- Repositório agora utiliza `pd.read_excel`.
- Adicionado `requirements.txt` com pandas, openpyxl e streamlit.
- `setup.sh` instala dependências a partir do arquivo de requirements.
- README atualizado com nova instrução de instalação e uso de arquivo `.xlsx`.

## Como testar
1. Execute `ruff check .` e `ruff format .`.
2. Rode `pytest -q` (vai falhar sem pandas instalado).


------
https://chatgpt.com/codex/tasks/task_e_685c25948500832cba192e2b5edbcd96