### PR TITLE
feat: suporte a xls e xlsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Support for `.xls` files in `OrderServiceXLSRepository` using `xlrd`.
+- Dependency `xlrd>=2.0.1` listed in `requirements.txt`.
+- Documentation updated to mention optional `xlrd` installation.
+

--- a/README.md
+++ b/README.md
@@ -14,12 +14,18 @@ pip install -r requirements.txt
 
 ## Execução da aplicação
 
-1. Coloque o arquivo `ordens_servico.xls` em uma pasta `data/` na raiz do projeto. O formato esperado pode ser visto em `tests/fixtures/sample_orders.xls`.
+1. Coloque o arquivo `ordens_servico.xls` ou `ordens_servico.xlsx` em uma pasta `data/` na raiz do projeto. O formato esperado pode ser visto em `tests/fixtures/sample_orders.xls`.
 2. Execute:
 
 ```bash
 pip install -r requirements.txt
 streamlit run presentation/streamlit_app.py
+```
+
+Se utilizar um arquivo `.xls`, instale também a dependência opcional `xlrd`:
+
+```bash
+pip install xlrd
 ```
 
 ## Testes e qualidade de código

--- a/infrastructure/xls_repository.py
+++ b/infrastructure/xls_repository.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-import pandas as pd
+import os
 from pathlib import Path
 from typing import List
+
+import pandas as pd
 
 from domain.entities import OrderService
 
@@ -26,7 +28,9 @@ class OrderServiceXLSRepository:
         Returns:
             Lista de :class:`OrderService` carregadas do arquivo.
         """
-        df = pd.read_excel(self._file_path, engine="openpyxl")
+        ext = os.path.splitext(self._file_path)[1].lower()
+        engine = "xlrd" if ext == ".xls" else "openpyxl"
+        df = pd.read_excel(self._file_path, engine=engine)
         df = df.where(pd.notnull(df), None)
         orders = []
         for row in df.to_dict(orient="records"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas>=2.0.0
 openpyxl>=3.0.0
+xlrd>=2.0.1
 streamlit


### PR DESCRIPTION
## Contexto
Era necessário permitir a leitura de planilhas no formato BIFF (`.xls`). Ao utilizar o `OrderServiceXLSRepository` com esses arquivos ocorria `BadZipFile`.

## Mudanças
- detecta a extensão do arquivo e define automaticamente o engine do pandas
- adiciona `xlrd>=2.0.1` às dependências
- atualiza README com instruções para uso de `.xls`
- cria CHANGELOG para registrar a adição

## Como testar
1. `pip install -r requirements.txt` (requer internet)
2. `streamlit run presentation/streamlit_app.py`
3. Coloque um arquivo `ordens_servico.xls` ou `.xlsx` em `data/` e verifique a carga sem erros

Para validar qualidade:
```bash
ruff check .
ruff format .
pytest -q
```


------
https://chatgpt.com/codex/tasks/task_e_685c34da1af0832c89a6c188adc0754c