### PR TITLE
Integrate Arkmeds API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+.env
+.streamlit/secrets.toml

--- a/README.md
+++ b/README.md
@@ -14,19 +14,24 @@ pip install -r requirements.txt
 
 ## Execução da aplicação
 
-1. Coloque o arquivo `ordens_servico.xls` ou `ordens_servico.xlsx` em uma pasta `data/` na raiz do projeto. O formato esperado pode ser visto em `tests/fixtures/sample_orders.xls`.
+1. Defina as variáveis de ambiente da API Arkmeds (pode ser em um arquivo `.env`
+   ou em `.streamlit/secrets.toml`):
+
+   ```bash
+   ARKMEDS_EMAIL=<seu-email>
+   ARKMEDS_PASSWORD=<sua-senha>
+   BASE_URL=https://api-os.arkmeds.com
+   ```
+
+   Para apontar para ambientes de staging ou produção, altere o valor de
+   `BASE_URL` conforme necessário.
+
 2. Execute:
 
-```bash
-pip install -r requirements.txt
-streamlit run presentation/streamlit_app.py
-```
-
-Se utilizar um arquivo `.xls`, instale também a dependência opcional `xlrd`:
-
-```bash
-pip install xlrd
-```
+   ```bash
+   pip install -r requirements.txt
+   streamlit run presentation/streamlit_app.py
+   ```
 
 ## Testes e qualidade de código
 

--- a/infrastructure/arkmeds_client.py
+++ b/infrastructure/arkmeds_client.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict, Optional
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BASE_URL = os.getenv("BASE_URL", "https://api-os.arkmeds.com")
+EMAIL = os.getenv("ARKMEDS_EMAIL")
+PASSWORD = os.getenv("ARKMEDS_PASSWORD")
+
+_TOKEN: Optional[str] = None
+_TS = 0.0
+TTL = 3600  # 1 hour
+
+
+def set_credentials(email: str, password: str) -> None:
+    """Configure credentials used to authenticate with Arkmeds."""
+    global EMAIL, PASSWORD, _TOKEN, _TS
+    EMAIL = email
+    PASSWORD = password
+    _TOKEN = None
+    _TS = 0.0
+
+
+def get_token(force: bool = False) -> str:
+    """Return a valid token, refreshing if necessary."""
+    global _TOKEN, _TS
+    if not force and _TOKEN and time.time() - _TS < TTL:
+        return _TOKEN
+    if not EMAIL or not PASSWORD:
+        raise RuntimeError("Credenciais Arkmeds não configuradas")
+    resp = requests.post(
+        f"{BASE_URL}/rest-auth/token-auth/",
+        json={"email": EMAIL, "password": PASSWORD},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    _TOKEN = resp.json()["token"]
+    _TS = time.time()
+    return _TOKEN
+
+
+def _request(method: str, endpoint: str, **kwargs: Any) -> Any:
+    """Execute an authenticated request against the Arkmeds API."""
+    headers: Dict[str, str] = kwargs.pop("headers", {})
+    headers["Authorization"] = f"Token {get_token()}"
+    resp = requests.request(
+        method, f"{BASE_URL}{endpoint}", headers=headers, timeout=15, **kwargs
+    )
+    if resp.status_code == 401:
+        headers["Authorization"] = f"Token {get_token(force=True)}"
+        resp = requests.request(
+            method, f"{BASE_URL}{endpoint}", headers=headers, timeout=15, **kwargs
+        )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_assets(**params: Any) -> Any:
+    """Retrieve asset list from the API."""
+    return _request("GET", "/assets/", params=params)
+
+
+def get_workorders(status: Optional[str] = None, **params: Any) -> Any:
+    """Retrieve work orders, optionally filtering by status."""
+    if status is not None:
+        params["status"] = status
+    return _request("GET", "/workorders/", params=params)
+
+
+def get_tickets(status: Optional[str] = None, **params: Any) -> Any:
+    """Retrieve tickets, optionally filtering by status."""
+    if status is not None:
+        params["status"] = status
+    return _request("GET", "/tickets/", params=params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pandas>=2.0.0
 openpyxl>=3.0.0
 xlrd>=2.0.1
 streamlit
+requests
+python-dotenv


### PR DESCRIPTION
## Summary
- add Arkmeds API client to fetch assets, workorders and tickets
- update Streamlit dashboard to pull data from Arkmeds
- document environment variables for API auth
- ignore env/secrets files in Git
- add requests and python-dotenv requirements

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687912def028832c8e45db78617901ff