### PR TITLE
Add support for preset API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ pip install -r requirements.txt
    ```bash
    ARKMEDS_EMAIL=<seu-email>
    ARKMEDS_PASSWORD=<sua-senha>
+   # Opcional: informe um token obtido previamente
+   ARKMEDS_TOKEN=<seu-token>
    BASE_URL=https://api-os.arkmeds.com
    ```
 

--- a/infrastructure/arkmeds_client.py
+++ b/infrastructure/arkmeds_client.py
@@ -17,6 +17,8 @@ BASE_URL = os.getenv("BASE_URL")
 # Credenciais padrão podem ser definidas via variáveis de ambiente
 EMAIL = os.getenv("ARKMEDS_EMAIL")
 PASSWORD = os.getenv("ARKMEDS_PASSWORD")
+# Token definido manualmente via variável de ambiente ou ``set_token``
+_TOKEN_OVERRIDE: Optional[str] = os.getenv("ARKMEDS_TOKEN")
 
 # Token obtido após a autenticação; guardado em memória
 _TOKEN: Optional[str] = None
@@ -35,9 +37,17 @@ def set_credentials(email: str, password: str) -> None:
     _TS = 0.0
 
 
+def set_token(token: str) -> None:
+    """Configure a fixed authentication token."""
+    global _TOKEN_OVERRIDE
+    _TOKEN_OVERRIDE = token
+
+
 def get_token(force: bool = False) -> str:
     """Return a valid token, refreshing if necessary."""
     global _TOKEN, _TS
+    if _TOKEN_OVERRIDE:
+        return _TOKEN_OVERRIDE
     if not force and _TOKEN and time.time() - _TS < TTL:
         return _TOKEN
     if not EMAIL or not PASSWORD:


### PR DESCRIPTION
## Summary
- allow Arkmeds token to be supplied via env or secrets
- enable Streamlit login using a token
- document new `ARKMEDS_TOKEN` variable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68792af5fa78832c89959eb3d868e99f