### PR TITLE
Fix ordem_servico endpoint

### DIFF
--- a/.streamlit/secrets.example.toml
+++ b/.streamlit/secrets.example.toml
@@ -2,4 +2,4 @@ ARKMEDS_EMAIL = ""
 ARKMEDS_PASSWORD = ""
 # ARKMEDS_TOKEN = ""
 # BASE_URL = "https://<slug>.arkmeds.com"
-# ARKMEDS_API_PREFIX = "/api/v2"  # opcional
+# ARKMEDS_API_PREFIX = "/api/v5"   # mantenha vazio se BASE_URL já incluir o prefixo

--- a/README.md
+++ b/README.md
@@ -26,19 +26,28 @@ pip install -r requirements.txt
    ARKMEDS_TOKEN=<seu-token>
    BASE_URL=https://<slug>.arkmeds.com
    # Opcional quando ``BASE_URL`` não inclui o prefixo
-   ARKMEDS_API_PREFIX=/api/v2
+   ARKMEDS_API_PREFIX=/api/v5   # deixe vazio se ``BASE_URL`` já inclui o prefixo
    ```
 
    Você pode definir ``BASE_URL`` de duas formas:
 
-   1. ``BASE_URL=https://<slug>.arkmeds.com/api/v2``
-   2. ``BASE_URL=https://<slug>.arkmeds.com`` e ``ARKMEDS_API_PREFIX=/api/v2``
+   1. ``BASE_URL=https://<slug>.arkmeds.com/api/v5``
+   2. ``BASE_URL=https://<slug>.arkmeds.com`` e ``ARKMEDS_API_PREFIX=/api/v5``
 
 2. Inicie a aplicação via Streamlit:
 
    ```bash
+
    streamlit run presentation/streamlit_app.py
    ```
+
+## Endpoints principais
+
+- Ordens de Serviço: `/api/v5/ordem_servico/`
+- Chamados: `/api/v5/chamado/`
+- Peças: `/api/v2/part/`
+
+Caso sua instância utilize outra versão, ajuste a variável ``ARKMEDS_API_PREFIX``.
 
 ## Testes e qualidade de código
 

--- a/infrastructure/arkmeds_client.py
+++ b/infrastructure/arkmeds_client.py
@@ -15,7 +15,7 @@ load_dotenv()
 # URL base da API
 BASE_URL = os.getenv("BASE_URL")
 # Prefixo usado por todos os endpoints de dados
-API_PREFIX = os.getenv("ARKMEDS_API_PREFIX", "/api/v2").rstrip("/")
+API_PREFIX = os.getenv("ARKMEDS_API_PREFIX", "/api/v5").rstrip("/")
 # Credenciais padrão podem ser definidas via variáveis de ambiente
 EMAIL = os.getenv("ARKMEDS_EMAIL")
 PASSWORD = os.getenv("ARKMEDS_PASSWORD")
@@ -96,11 +96,16 @@ def get_assets(**params: Any) -> Any:
     return _request("GET", "assets/", params=params)
 
 
-def get_workorders(status: Optional[str] = None, **params: Any) -> Any:
-    """Retrieve work orders, optionally filtering by status."""
-    if status is not None:
-        params["status"] = status
-    return _request("GET", "workorders/", params=params)
+def get_ordens_servico(page: int | None = None, page_size: int = 30) -> Any:
+    """Retrieve ordens de serviço from the API."""
+    params = (
+        {"page": page, "page_size": page_size} if page else {"page_size": page_size}
+    )
+    return _request("GET", "ordem_servico/", params=params)
+
+
+# Mantém alias para retrocompatibilidade
+get_workorders = get_ordens_servico
 
 
 def get_tickets(status: Optional[str] = None, **params: Any) -> Any:

--- a/presentation/streamlit_app.py
+++ b/presentation/streamlit_app.py
@@ -61,10 +61,10 @@ def ensure_login() -> bool:
 
 
 @st.cache_data(ttl=600)
-def load_orders() -> List[OrderService]:
-    """Fetch work orders from Arkmeds API."""
+def load_orders(api_prefix: str = arkmeds_client.API_PREFIX) -> List[OrderService]:
+    """Fetch ordens de serviço from Arkmeds API."""
     # Consulta a API e converte cada item para a entidade ``OrderService``
-    data = arkmeds_client.get_workorders()
+    data = arkmeds_client.get_ordens_servico()
     orders: List[OrderService] = []
     for item in data:
         orders.append(

--- a/scripts/test_api.py
+++ b/scripts/test_api.py
@@ -2,7 +2,7 @@ from infrastructure import arkmeds_client
 import requests
 
 try:
-    arkmeds_client.get_workorders()
+    arkmeds_client.get_ordens_servico()
 except requests.HTTPError as exc:
     if exc.response.status_code == 404:
         raise SystemExit("Unexpected 404 from API") from exc

--- a/scripts/test_ordem_servico.py
+++ b/scripts/test_ordem_servico.py
@@ -1,0 +1,9 @@
+from infrastructure import arkmeds_client
+import requests
+
+try:
+    arkmeds_client.get_ordens_servico(page_size=1)
+except requests.HTTPError as exc:
+    raise SystemExit(f"Unexpected status {exc.response.status_code}") from exc
+else:
+    print("Request succeeded")


### PR DESCRIPTION
## Summary
- update Arkmeds API prefix default to `/api/v5`
- add helper `get_ordens_servico` and alias `get_workorders`
- refresh Streamlit UI to use the new helper
- document new endpoint and env var usage
- add example secrets and new test script

## Testing
- `ruff check .`
- `ruff format .`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6879391795c8832c9b66189a38e9c74c