### PR TITLE
Implement JWT prefix support

### DIFF
--- a/.streamlit/secrets.example.toml
+++ b/.streamlit/secrets.example.toml
@@ -3,3 +3,5 @@ ARKMEDS_PASSWORD = ""
 # ARKMEDS_TOKEN = ""
 # BASE_URL = "https://<slug>.arkmeds.com"
 # ARKMEDS_API_PREFIX = "/api/v5"   # mantenha vazio se BASE_URL já incluir o prefixo
+# Prefixo de autenticação (default = JWT)
+# ARKMEDS_AUTH_PREFIX = "JWT"

--- a/README.md
+++ b/README.md
@@ -27,12 +27,25 @@ pip install -r requirements.txt
    BASE_URL=https://<slug>.arkmeds.com
    # Opcional quando ``BASE_URL`` não inclui o prefixo
    ARKMEDS_API_PREFIX=/api/v5   # deixe vazio se ``BASE_URL`` já inclui o prefixo
+   # Prefixo do cabeçalho de autenticação (padrão JWT)
+   # ARKMEDS_AUTH_PREFIX=JWT
    ```
 
    Você pode definir ``BASE_URL`` de duas formas:
 
    1. ``BASE_URL=https://<slug>.arkmeds.com/api/v5``
    2. ``BASE_URL=https://<slug>.arkmeds.com`` e ``ARKMEDS_API_PREFIX=/api/v5``
+
+### Autenticação
+
+A Arkmeds utiliza JSON Web Token (JWT). O cabeçalho deve conter:
+
+```
+Authorization: JWT <token>
+```
+
+Caso sua instância utilize outro prefixo, defina ``ARKMEDS_AUTH_PREFIX`` nas
+variáveis de ambiente ou em ``.streamlit/secrets.toml``.
 
 2. Inicie a aplicação via Streamlit:
 

--- a/tests/test_auth_header.py
+++ b/tests/test_auth_header.py
@@ -1,0 +1,36 @@
+"""Ensure the authorization prefix is applied."""
+# ruff: noqa: E402
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+requests = pytest.importorskip("requests")
+from infrastructure import arkmeds_client
+
+
+def test_auth_prefix(monkeypatch) -> None:
+    arkmeds_client.AUTH_PREFIX = "JWT"
+
+    def fake_request(method, url, headers=None, timeout=15, **kwargs):
+        fake_request.captured = headers
+
+        class DummyResp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {}
+
+        return DummyResp()
+
+    monkeypatch.setattr(arkmeds_client, "get_token", lambda force=False: "abc.def.ghi")
+    monkeypatch.setattr(requests, "request", fake_request)
+
+    arkmeds_client._request("GET", "company/")
+    assert fake_request.captured["Authorization"].startswith("JWT ")


### PR DESCRIPTION
## Summary
- make auth prefix configurable via `AUTH_PREFIX`
- document JWT authorization header usage
- update secrets example
- test header includes the JWT prefix

## Testing
- `ruff check infrastructure/arkmeds_client.py tests/test_auth_header.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac49e28b4832c894dc52b1baac314