### PR TITLE
Add secrets example template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ poetry.lock
 *~
 
 # secrets
-.streamlit/secrets.toml
+/.streamlit/secrets.toml
 
 # IDE
 .idea/

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,0 +1,9 @@
+[arkmeds]
+email = "seu.email@exemplo.com"
+password = "SENHA_AQUI"
+base_url = "https://dominio.arkmeds.com"
+token = "JWT_AQUI (opcional – será gerado se vazio)"
+
+[app]
+cache_ttl = 900 # segundos
+max_retries = 3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ app/
 ```
 
 ## Configuração de secrets
-Copie `secrets.toml.example` para `.streamlit/secrets.toml` e preencha os campos necessários.
+1. Copie o arquivo de exemplo:
+   ```bash
+   cp .streamlit/secrets.toml.example .streamlit/secrets.toml
+   ```
+2. Preencha as variáveis com suas credenciais reais.
+3. Opcionalmente deixe `token` vazio para que o login seja feito automaticamente.
 
 ## Contribuindo
 1. Instale os hooks do pre-commit dentro do ambiente do Poetry:

--- a/app/arkmeds_client/auth.py
+++ b/app/arkmeds_client/auth.py
@@ -1,0 +1,7 @@
+import streamlit as st
+
+cfg = st.secrets["arkmeds"]
+EMAIL = cfg.get("email")
+PASSWORD = cfg.get("password")
+BASE_URL = cfg.get("base_url")
+TOKEN = cfg.get("token")


### PR DESCRIPTION
## Summary
- provide `.streamlit/secrets.toml.example`
- document secrets setup in README
- ignore real secrets path
- add simple auth helper showing how to load secrets

## Testing
- `poetry run pre-commit run --files .gitignore README.md .streamlit/secrets.toml.example app/arkmeds_client/auth.py`

------
https://chatgpt.com/codex/tasks/task_e_687edcfd6038832cad7c8160991baed8