### PR TITLE
Implement ArkmedsClient with pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ auth = ArkmedsAuth.from_secrets()
 token = await auth.get_token()
 ```
 
+## Uso do ArkmedsClient
+
+```python
+from arkmeds_client.auth import ArkmedsAuth
+from arkmeds_client.client import ArkmedsClient
+
+auth = ArkmedsAuth.from_secrets()
+client = ArkmedsClient(auth)
+os = await client.list_os(data_criacao__gte="2025-06-01")
+```
+
 ## Contribuindo
 1. Instale os hooks do pre-commit dentro do ambiente do Poetry:
    ```bash

--- a/app/arkmeds_client/client.py
+++ b/app/arkmeds_client/client.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import httpx
+from aiolimiter import AsyncLimiter
+
+from .auth import ArkmedsAuth
+from .models import PaginatedResponse
+
+
+class ArkmedsClient:
+    def __init__(
+        self,
+        auth: ArkmedsAuth,
+        *,
+        timeout: float = 5.0,
+        max_retries: int = 3,
+        rate: int = 10,
+    ) -> None:
+        self.auth = auth
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.limiter = AsyncLimiter(max_rate=rate, time_period=1)
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if not self._client:
+            token = await self.auth.get_token()
+            headers = {"Authorization": f"Bearer {token}"}
+            self._client = httpx.AsyncClient(
+                base_url=self.auth.base_url, timeout=self.timeout, headers=headers
+            )
+        return self._client
+
+    async def _request(
+        self, method: str, url: str, *, params: Optional[Dict[str, Any]] = None
+    ) -> httpx.Response:
+        client = await self._get_client()
+        for attempt in range(self.max_retries):
+            try:
+                async with self.limiter:
+                    resp = await client.request(method, url, params=params)
+                if resp.status_code == 401 and attempt == 0:
+                    await self.auth.login()
+                    client.headers["Authorization"] = f"Bearer {await self.auth.get_token()}"
+                    continue
+                if resp.status_code >= 500 or resp.status_code == 429:
+                    if attempt == self.max_retries - 1:
+                        resp.raise_for_status()
+                    await asyncio.sleep(2**attempt)
+                    continue
+                resp.raise_for_status()
+                return resp
+            except httpx.RequestError:
+                if attempt == self.max_retries - 1:
+                    raise
+                await asyncio.sleep(2**attempt)
+        raise httpx.HTTPError("Max retries exceeded")
+
+    async def _get_all_pages(self, endpoint: str, params: Dict[str, Any]) -> List[dict]:
+        params = params.copy()
+        params.setdefault("page", 1)
+        params.setdefault("page_size", 100)
+
+        url = endpoint
+        results: List[dict] = []
+        while url:
+            resp = await self._request("GET", url, params=params if url == endpoint else None)
+            data = PaginatedResponse.model_validate(resp.json())
+            results.extend(data.results)
+            url = data.next
+            params = None
+        return results
+
+    async def list_os(self, **filters: Any) -> List[dict]:
+        return await self._get_all_pages("/api/v3/ordem_servico/", filters)
+
+    async def list_equipment(self, **filters: Any) -> List[dict]:
+        return await self._get_all_pages("/api/v3/equipamento/", filters)
+
+    async def list_users(self, **filters: Any) -> List[dict]:
+        return await self._get_all_pages("/api/v3/users/", filters)
+

--- a/app/arkmeds_client/models.py
+++ b/app/arkmeds_client/models.py
@@ -1,7 +1,14 @@
 from datetime import datetime
+
 from pydantic import BaseModel
 
 
 class TokenData(BaseModel):
     token: str
     exp: datetime
+
+
+class PaginatedResponse(BaseModel):
+    count: int
+    next: str | None = None
+    results: list[dict]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "pandas (>=2,<3)",
     "plotly (>=5,<6)",
     "cachetools (>=5,<6)",
-    "python-dateutil (>=2,<3)"
+    "python-dateutil (>=2,<3)",
+    "aiolimiter (>=1,<2) ; python_version >= \"3.12\" and python_version < \"4.0\""
 ]
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,117 @@
+from datetime import datetime, timedelta, timezone
+import asyncio
+
+import httpx
+from httpx import Response, Request
+from httpx import MockTransport
+
+from app.arkmeds_client.auth import ArkmedsAuth
+from app.arkmeds_client.client import ArkmedsClient
+from app.arkmeds_client.models import TokenData
+
+
+class DummyAuth(ArkmedsAuth):
+    def __init__(self) -> None:
+        super().__init__(email="a", password="b", base_url="https://api.test")
+
+    async def login(self) -> TokenData:  # type: ignore[override]
+        self._token = TokenData(
+            token="x",
+            exp=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        return self._token
+
+    async def refresh(self) -> None:  # type: ignore[override]
+        return
+
+
+def make_client(responses):
+    async def handler(request: Request) -> Response:
+        path = request.url.path
+        query = request.url.query.decode()
+        if path == "/api/v3/ordem_servico/" and "page=2" in query:
+            return responses.pop("/api/v3/ordem_servico/?page=2")
+        return responses.pop("/api/v3/ordem_servico/")
+
+    transport = MockTransport(handler)
+    auth = DummyAuth()
+    client = ArkmedsClient(auth)
+    client._client = httpx.AsyncClient(base_url=auth.base_url, transport=transport)
+    return client
+
+
+def test_paginated_success():
+    responses = {
+        "/api/v3/ordem_servico/": Response(
+            200,
+            json={
+                "count": 3,
+                "next": "https://api.test/api/v3/ordem_servico/?page=2",
+                "results": [{"id": 1}],
+            },
+        ),
+        "/api/v3/ordem_servico/?page=2": Response(
+            200,
+            json={"count": 3, "next": None, "results": [{"id": 2}, {"id": 3}]},
+        ),
+    }
+    client = make_client(responses)
+    data = asyncio.run(client.list_os())
+    assert len(data) == 3
+
+
+def test_401_refresh_once():
+    responses = {
+        "/api/v3/ordem_servico/": Response(401),
+        "retry": Response(
+            200,
+            json={"count": 1, "next": None, "results": [{"id": 1}]},
+        ),
+    }
+
+    async def handler(request: Request) -> Response:
+        path = request.url.raw_path.decode()
+        if path == "/api/v3/ordem_servico/" and not getattr(handler, "called", False):
+            handler.called = True
+            return responses[path]
+        return responses["retry"]
+
+    transport = MockTransport(handler)
+    auth = DummyAuth()
+    client = ArkmedsClient(auth)
+    client._client = httpx.AsyncClient(base_url=auth.base_url, transport=transport)
+    data = asyncio.run(client.list_os())
+    assert len(data) == 1
+
+
+def test_retry_5xx():
+    calls = []
+
+    async def handler(request: Request) -> Response:
+        calls.append(1)
+        if len(calls) < 3:
+            return Response(500)
+        return Response(
+            200,
+            json={"count": 1, "next": None, "results": [{"id": 1}]},
+        )
+
+    transport = MockTransport(handler)
+    auth = DummyAuth()
+    client = ArkmedsClient(auth, max_retries=3)
+    client._client = httpx.AsyncClient(base_url=auth.base_url, transport=transport)
+    data = asyncio.run(client.list_os())
+    assert len(data) == 1
+    assert len(calls) == 3
+
+
+def test_filters_in_query():
+    async def handler(request: Request) -> Response:
+        assert b"estado=4" in request.url.query
+        return Response(200, json={"count": 0, "next": None, "results": []})
+
+    transport = MockTransport(handler)
+    auth = DummyAuth()
+    client = ArkmedsClient(auth)
+    client._client = httpx.AsyncClient(base_url=auth.base_url, transport=transport)
+    asyncio.run(client.list_os(estado=4))


### PR DESCRIPTION
## Summary
- add aiolimiter dependency
- implement `PaginatedResponse` model
- create async `ArkmedsClient`
- document client usage in README
- add tests for the client

## Testing
- `ruff check .`
- `PYTHONPATH=. poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee5898cf8832c916bf1cef8226368