### PR TITLE
Implement OS KPI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,17 @@ os_obj: OS = OS.model_validate(raw)
    ```bash
    pre-commit autoupdate
    ```
+
+## KPIs de OS
+
+```python
+from app.services.os_metrics import compute_metrics
+from app.arkmeds_client.auth import ArkmedsAuth
+from app.arkmeds_client.client import ArkmedsClient
+from datetime import date
+
+auth = ArkmedsAuth.from_secrets()
+client = ArkmedsClient(auth)
+metrics = await compute_metrics(client, dt_ini=date(2025, 1, 1), dt_fim=date(2025, 1, 31))
+print(metrics)
+```

--- a/app/config/os_types.py
+++ b/app/config/os_types.py
@@ -1,0 +1,11 @@
+"""Mappings for OS types and areas.
+
+Edit IDs if API mappings change.
+"""
+
+# TODO: update IDs via environment if needed
+TIPO_CORRETIVA = 2
+TIPO_PREVENTIVA = 1
+TIPO_BUSCA_ATIVA = 6
+AREA_PREDIAL = 10
+AREA_ENG_CLIN = 11

--- a/app/services/os_metrics.py
+++ b/app/services/os_metrics.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import date, timedelta
+from typing import Any, Tuple
+
+import httpx
+import streamlit as st
+from pydantic import BaseModel
+
+from app.arkmeds_client.auth import ArkmedsAuthError
+from app.arkmeds_client.client import ArkmedsClient
+from app.arkmeds_client.models import OSEstado
+from app.config.os_types import (
+    AREA_ENG_CLIN,
+    AREA_PREDIAL,
+    TIPO_BUSCA_ATIVA,
+    TIPO_CORRETIVA,
+    TIPO_PREVENTIVA,
+)
+
+SLA_HOURS = int(os.getenv("OS_SLA_HOURS", 72))
+
+
+class OSMetricsError(Exception):
+    """Raised when metrics computation fails."""
+
+
+class OSMetrics(BaseModel):
+    corretivas_predial: int
+    corretivas_engenharia: int
+    preventivas_predial: int
+    preventivas_infra: int
+    busca_ativa: int
+    backlog: int
+    sla_pct: float
+
+
+async def _async_compute(
+    client: ArkmedsClient, *, dt_ini: date, dt_fim: date, filters: dict[str, Any]
+) -> OSMetrics:
+    async def fetch(tipo_id: int, area_id: int | None = None, **extra: Any):
+        params: dict[str, Any] = {
+            "tipo_id": tipo_id,
+            "data_criacao__gte": dt_ini,
+            "data_criacao__lte": dt_fim,
+            **filters,
+            **extra,
+        }
+        if area_id is not None:
+            params["area_id"] = area_id
+        return await client.list_os(**params)
+
+    try:
+        (
+            corretivas_predial,
+            corretivas_eng,
+            preventivas_predial,
+            preventivas_infra,
+            busca,
+            abertas,
+            fechadas,
+            fechadas_periodo,
+        ) = await asyncio.gather(
+            fetch(TIPO_CORRETIVA, AREA_PREDIAL),
+            fetch(TIPO_CORRETIVA, AREA_ENG_CLIN),
+            fetch(TIPO_PREVENTIVA, AREA_PREDIAL),
+            fetch(TIPO_PREVENTIVA, AREA_ENG_CLIN),
+            fetch(TIPO_BUSCA_ATIVA),
+            fetch(TIPO_CORRETIVA, estado_ids=[OSEstado.ABERTA.value]),
+            fetch(TIPO_CORRETIVA, estado_ids=[OSEstado.FECHADA.value]),
+            fetch(
+                TIPO_CORRETIVA,
+                estado_ids=[OSEstado.FECHADA.value],
+                data_fechamento__gte=dt_ini,
+                data_fechamento__lte=dt_fim,
+            ),
+        )
+    except (httpx.TimeoutException, ArkmedsAuthError) as exc:
+        raise OSMetricsError("failed to fetch OS data") from exc
+
+    backlog = len(abertas) - len(fechadas)
+
+    within_sla = 0
+    for os_obj in fechadas_periodo:
+        if os_obj.closed_at and os_obj.closed_at - os_obj.created_at <= timedelta(hours=SLA_HOURS):
+            within_sla += 1
+    sla_pct = (within_sla / len(fechadas_periodo) * 100) if fechadas_periodo else 0.0
+
+    return OSMetrics(
+        corretivas_predial=len(corretivas_predial),
+        corretivas_engenharia=len(corretivas_eng),
+        preventivas_predial=len(preventivas_predial),
+        preventivas_infra=len(preventivas_infra),
+        busca_ativa=len(busca),
+        backlog=backlog,
+        sla_pct=round(sla_pct, 2),
+    )
+
+
+def _freeze_filters(filters: dict[str, Any]) -> Tuple[Tuple[str, Any], ...]:
+    return tuple(sorted(filters.items()))
+
+
+@st.cache_data(ttl=900)
+def _cached_compute(
+    dt_ini: date,
+    dt_fim: date,
+    frozen_filters: Tuple[Tuple[str, Any], ...],
+    _client: ArkmedsClient,
+) -> OSMetrics:
+    filters = dict(frozen_filters)
+    return asyncio.run(_async_compute(_client, dt_ini=dt_ini, dt_fim=dt_fim, filters=filters))
+
+
+async def compute_metrics(
+    client: ArkmedsClient, *, dt_ini: date, dt_fim: date, **filters: Any
+) -> OSMetrics:
+    frozen = _freeze_filters(filters)
+    return await asyncio.to_thread(_cached_compute, dt_ini, dt_fim, frozen, client)

--- a/tests/test_os_metrics.py
+++ b/tests/test_os_metrics.py
@@ -1,0 +1,93 @@
+from datetime import datetime, date
+
+import pytest
+
+from app.services.os_metrics import compute_metrics
+from app.services.os_metrics import OSMetrics
+from app.arkmeds_client.models import OS, OSEstado
+
+
+class DummyClient:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    async def list_os(self, **filters):
+        key = filters.get("label")
+        return self.mapping.get(key, [])
+
+
+def make_os(id, tipo, estado, created, closed=None):
+    payload = {
+        "id": id,
+        "tipo_ordem_servico": {"id": tipo, "descricao": "t"},
+        "estado": {"id": estado, "descricao": "e"},
+        "data_criacao": created.strftime("%d/%m/%y - %H:%M"),
+        "data_fechamento": closed.strftime("%d/%m/%y - %H:%M") if closed else None,
+    }
+    return OS.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_compute_metrics():
+    dt_ini = date(2025, 1, 1)
+    dt_fim = date(2025, 1, 31)
+
+    data = {
+        "cor_predial": [make_os(1, 2, 1, datetime(2025, 1, 5))],
+        "cor_eng": [make_os(2, 2, 1, datetime(2025, 1, 6)) for _ in range(2)],
+        "prev_predial": [make_os(3, 1, 1, datetime(2025, 1, 7)) for _ in range(3)],
+        "prev_infra": [make_os(4, 1, 1, datetime(2025, 1, 8))],
+        "busca": [make_os(5, 6, 1, datetime(2025, 1, 9)) for _ in range(4)],
+        "abertas": [make_os(6, 2, OSEstado.ABERTA.value, datetime(2025, 1, 10)) for _ in range(6)],
+        "fechadas": [make_os(7, 2, OSEstado.FECHADA.value, datetime(2025, 1, 11)) for _ in range(2)],
+        "fechadas_periodo": [
+            make_os(
+                8,
+                2,
+                OSEstado.FECHADA.value,
+                datetime(2025, 1, 12),
+                datetime(2025, 1, 13),
+            ),
+            make_os(
+                9,
+                2,
+                OSEstado.FECHADA.value,
+                datetime(2025, 1, 14),
+                datetime(2025, 2, 20),
+            ),
+        ],
+    }
+
+    client = DummyClient(data)
+
+    async def fake_list_os(**filters):
+        if filters.get("estado_ids") == [OSEstado.ABERTA.value]:
+            return data["abertas"]
+        if filters.get("data_fechamento__gte"):
+            return data["fechadas_periodo"]
+        if filters.get("estado_ids") == [OSEstado.FECHADA.value]:
+            return data["fechadas"]
+        if filters.get("tipo_id") == 2 and filters.get("area_id") == 10:
+            return data["cor_predial"]
+        if filters.get("tipo_id") == 2 and filters.get("area_id") == 11:
+            return data["cor_eng"]
+        if filters.get("tipo_id") == 1 and filters.get("area_id") == 10:
+            return data["prev_predial"]
+        if filters.get("tipo_id") == 1 and filters.get("area_id") == 11:
+            return data["prev_infra"]
+        if filters.get("tipo_id") == 6:
+            return data["busca"]
+        return []
+
+    client.list_os = fake_list_os  # type: ignore[assignment]
+
+    metrics = await compute_metrics(client, dt_ini=dt_ini, dt_fim=dt_fim)
+
+    assert isinstance(metrics, OSMetrics)
+    assert metrics.corretivas_predial == 1
+    assert metrics.corretivas_engenharia == 2
+    assert metrics.preventivas_predial == 3
+    assert metrics.preventivas_infra == 1
+    assert metrics.busca_ativa == 4
+    assert metrics.backlog == 4
+    assert metrics.sla_pct == 50.0


### PR DESCRIPTION
## Summary
- add configuration of OS type and area IDs
- implement async KPI service with caching
- document OS KPI usage
- test OS metrics computation

## Testing
- `ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ef18eeda8832cbc07ca6f6b86ea1c