### PR TITLE
Implement equipment KPI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,17 @@ client = ArkmedsClient(auth)
 metrics = await compute_metrics(client, dt_ini=date(2025, 1, 1), dt_fim=date(2025, 1, 31))
 print(metrics)
 ```
+
+## KPIs de Equipamentos
+
+```python
+from app.services.equip_metrics import compute_metrics
+from app.arkmeds_client.auth import ArkmedsAuth
+from app.arkmeds_client.client import ArkmedsClient
+from datetime import date
+
+auth = ArkmedsAuth.from_secrets()
+client = ArkmedsClient(auth)
+metrics = await compute_metrics(client, dt_ini=date(2025, 1, 1), dt_fim=date(2025, 1, 31))
+print(metrics)
+```

--- a/app/arkmeds_client/models.py
+++ b/app/arkmeds_client/models.py
@@ -64,6 +64,7 @@ class OS(ArkBase):
     responsavel: User | None = None
     created_at: datetime = Field(alias="data_criacao")
     closed_at: datetime | None = Field(default=None, alias="data_fechamento")
+    equipment_id: int | None = Field(default=None, alias="equipamento_id")
 
     @field_validator("created_at", "closed_at", mode="before")
     @classmethod

--- a/app/config/equip_status.py
+++ b/app/config/equip_status.py
@@ -1,0 +1,4 @@
+"""Placeholder constants for equipment status IDs."""
+
+# Update these IDs if the API provides different mappings
+STATUS_MANUTENCAO = "MANUTENCAO"

--- a/app/services/equip_metrics.py
+++ b/app/services/equip_metrics.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from datetime import date
+from statistics import mean
+from typing import Any, Dict, Tuple
+
+import httpx
+import streamlit as st
+from pydantic import BaseModel
+
+from app.arkmeds_client.auth import ArkmedsAuthError
+from app.arkmeds_client.client import ArkmedsClient
+from app.arkmeds_client.models import OSEstado
+from app.config.os_types import TIPO_CORRETIVA
+
+
+class EquipMetricsError(Exception):
+    """Raised when equipment metrics computation fails."""
+
+
+class EquipMetrics(BaseModel):
+    ativos: int
+    desativados: int
+    em_manutencao: int
+    mttr_h: float
+    mtbf_h: float
+
+
+async def _async_compute(
+    client: ArkmedsClient, *, dt_ini: date, dt_fim: date, filters: Dict[str, Any]
+) -> EquipMetrics:
+    try:
+        equip_task = client.list_equipment()
+        os_task = client.list_os(
+            tipo_id=TIPO_CORRETIVA,
+            data_criacao__gte=dt_ini,
+            data_criacao__lte=dt_fim,
+            **filters,
+        )
+        equip_list, os_corr = await asyncio.gather(equip_task, os_task)
+    except (httpx.TimeoutException, ArkmedsAuthError) as exc:
+        raise EquipMetricsError("failed to fetch equipment data") from exc
+
+    ativos = sum(1 for eq in equip_list if getattr(eq, "ativo", True))
+    desativados = len(equip_list) - ativos
+
+    manutencao_ids = {
+        os_obj.equipment_id
+        for os_obj in os_corr
+        if os_obj.equipment_id is not None
+        and os_obj.estado.id != OSEstado.FECHADA.value
+    }
+    em_manutencao = len(manutencao_ids)
+
+    closed_durations = [
+        (os_obj.closed_at - os_obj.created_at).total_seconds()
+        for os_obj in os_corr
+        if os_obj.closed_at
+    ]
+    mttr_h = mean(closed_durations) / 3600 if closed_durations else 0.0
+
+    by_eq: Dict[int, list] = defaultdict(list)
+    for os_obj in os_corr:
+        if os_obj.equipment_id is not None and os_obj.closed_at:
+            by_eq[os_obj.equipment_id].append(os_obj)
+
+    intervals = []
+    for items in by_eq.values():
+        if len(items) < 2:
+            continue
+        items.sort(key=lambda o: o.created_at)
+        for i in range(1, len(items)):
+            intervals.append(
+                (items[i].created_at - items[i - 1].created_at).total_seconds()
+            )
+    mtbf_h = mean(intervals) / 3600 if intervals else 0.0
+
+    return EquipMetrics(
+        ativos=ativos,
+        desativados=desativados,
+        em_manutencao=em_manutencao,
+        mttr_h=round(mttr_h, 2),
+        mtbf_h=round(mtbf_h, 2),
+    )
+
+
+def _freeze_filters(filters: Dict[str, Any]) -> Tuple[Tuple[str, Any], ...]:
+    return tuple(sorted(filters.items()))
+
+
+@st.cache_data(ttl=900)
+def _cached_compute(
+    dt_ini: date,
+    dt_fim: date,
+    frozen_filters: Tuple[Tuple[str, Any], ...],
+    _client: ArkmedsClient,
+) -> EquipMetrics:
+    filters = dict(frozen_filters)
+    return asyncio.run(
+        _async_compute(_client, dt_ini=dt_ini, dt_fim=dt_fim, filters=filters)
+    )
+
+
+async def compute_metrics(
+    client: ArkmedsClient, *, dt_ini: date, dt_fim: date, **filters: Any
+) -> EquipMetrics:
+    frozen = _freeze_filters(filters)
+    return await asyncio.to_thread(_cached_compute, dt_ini, dt_fim, frozen, client)

--- a/tests/test_equip_metrics.py
+++ b/tests/test_equip_metrics.py
@@ -1,0 +1,77 @@
+from datetime import datetime, date
+
+import pytest
+
+from app.services.equip_metrics import compute_metrics, EquipMetrics
+from app.arkmeds_client.models import Equipment, OS, OSEstado
+from app.config.os_types import TIPO_CORRETIVA
+
+
+class DummyClient:
+    def __init__(self, equipments, os_list):
+        self._equipments = equipments
+        self._os = os_list
+
+    async def list_equipment(self, **filters):
+        return self._equipments
+
+    async def list_os(self, **filters):
+        assert filters.get("tipo_id") == TIPO_CORRETIVA
+        return self._os
+
+
+def make_equip(id, ativo=True):
+    payload = {"id": id, "nome": f"E{id}", "ativo": ativo}
+    return Equipment.model_validate(payload)
+
+
+def make_os(id, eq_id, estado, created, closed=None):
+    payload = {
+        "id": id,
+        "equipamento_id": eq_id,
+        "tipo_ordem_servico": {"id": TIPO_CORRETIVA, "descricao": "c"},
+        "estado": {"id": estado, "descricao": "e"},
+        "data_criacao": created.strftime("%d/%m/%y - %H:%M"),
+        "data_fechamento": closed.strftime("%d/%m/%y - %H:%M") if closed else None,
+    }
+    return OS.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_compute_equip_metrics():
+    equipments = [make_equip(1), make_equip(2, False), make_equip(3)]
+
+    os_list = [
+        make_os(1, 1, OSEstado.ABERTA.value, datetime(2025, 1, 5)),
+        make_os(
+            2,
+            1,
+            OSEstado.FECHADA.value,
+            datetime(2025, 1, 1),
+            datetime(2025, 1, 3),
+        ),
+        make_os(
+            3,
+            2,
+            OSEstado.FECHADA.value,
+            datetime(2025, 1, 2),
+            datetime(2025, 1, 5),
+        ),
+        make_os(
+            4,
+            1,
+            OSEstado.FECHADA.value,
+            datetime(2025, 1, 10),
+            datetime(2025, 1, 12),
+        ),
+    ]
+
+    client = DummyClient(equipments, os_list)
+    metrics = await compute_metrics(client, dt_ini=date(2025, 1, 1), dt_fim=date(2025, 1, 31))
+
+    assert isinstance(metrics, EquipMetrics)
+    assert metrics.ativos == 2
+    assert metrics.desativados == 1
+    assert metrics.em_manutencao == 1
+    assert metrics.mttr_h == 56.0
+    assert metrics.mtbf_h == 216.0


### PR DESCRIPTION
## Summary
- add equipment metrics computation service
- extend OS model with `equipment_id`
- document equipment KPI usage
- add placeholder equipment status config
- test equipment metrics calculations

## Testing
- `ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef693d304832ca5f89ee920335b4e