### PR TITLE
Implement technician KPI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,17 @@ client = ArkmedsClient(auth)
 metrics = await compute_metrics(client, dt_ini=date(2025, 1, 1), dt_fim=date(2025, 1, 31))
 print(metrics)
 ```
+
+## KPIs de Técnicos
+
+```python
+from app.services.tech_metrics import compute_metrics
+from app.arkmeds_client.auth import ArkmedsAuth
+from app.arkmeds_client.client import ArkmedsClient
+from datetime import date
+
+auth = ArkmedsAuth.from_secrets()
+client = ArkmedsClient(auth)
+metrics = await compute_metrics(client, dt_ini=date(2025, 1, 1), dt_fim=date(2025, 1, 31))
+print(metrics)
+```

--- a/app/arkmeds_client/models.py
+++ b/app/arkmeds_client/models.py
@@ -24,6 +24,7 @@ class ArkBase(BaseModel):
 class OSEstado(Enum):
     ABERTA = 1
     FECHADA = 4
+    CANCELADA = 5
 
 
 class TipoOS(ArkBase):

--- a/app/services/tech_metrics.py
+++ b/app/services/tech_metrics.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from collections import defaultdict
+from datetime import date
+from typing import Any, Dict, Tuple
+
+import httpx
+import streamlit as st
+from pydantic import BaseModel
+
+from app.arkmeds_client.auth import ArkmedsAuthError
+from app.arkmeds_client.client import ArkmedsClient
+from app.arkmeds_client.models import OSEstado
+
+SLA_HOURS = int(os.getenv("OS_SLA_HOURS", 72))
+
+
+class TechMetricsError(Exception):
+    """Raised when technician metrics computation fails."""
+
+
+class TechKPI(BaseModel):
+    tecnico_id: int
+    nome: str
+    abertas: int
+    concluidas: int
+    pendentes_total: int
+    sla_pct: float
+    avg_close_h: float
+
+
+async def _async_compute(
+    client: ArkmedsClient, *, dt_ini: date, dt_fim: date, filters: Dict[str, Any]
+) -> list[TechKPI]:
+    try:
+        os_list = await client.list_os(
+            data_criacao__lte=dt_fim,
+            estado_ids=[OSEstado.ABERTA.value, OSEstado.FECHADA.value],
+            **filters,
+        )
+    except (httpx.TimeoutException, ArkmedsAuthError) as exc:
+        raise TechMetricsError("failed to fetch OS data") from exc
+
+    valid = [o for o in os_list if o.estado.id != OSEstado.CANCELADA.value]
+
+    by_tech: Dict[int, list] = defaultdict(list)
+    for os_obj in valid:
+        if os_obj.responsavel:
+            by_tech[os_obj.responsavel.id].append(os_obj)
+
+    results: list[TechKPI] = []
+    for tech_id, items in by_tech.items():
+        nome = items[0].responsavel.nome if items[0].responsavel else "?"
+        abertas = len(
+            [
+                o
+                for o in items
+                if o.estado.id != OSEstado.FECHADA.value and o.created_at.date() >= dt_ini
+            ]
+        )
+        concluidas_list = [
+            o
+            for o in items
+            if o.estado.id == OSEstado.FECHADA.value
+            and o.closed_at
+            and dt_ini <= o.closed_at.date() <= dt_fim
+        ]
+        concluidas = len(concluidas_list)
+        pendentes_total = len([o for o in items if o.estado.id != OSEstado.FECHADA.value])
+
+        sla_ok = 0
+        total_h = 0.0
+        for o in concluidas_list:
+            delta_h = (o.closed_at - o.created_at).total_seconds() / 3600
+            total_h += delta_h
+            if delta_h <= SLA_HOURS:
+                sla_ok += 1
+        sla_pct = round(sla_ok / concluidas * 100, 1) if concluidas else 0.0
+        avg_close_h = round(total_h / concluidas, 2) if concluidas else 0.0
+
+        results.append(
+            TechKPI(
+                tecnico_id=tech_id,
+                nome=nome,
+                abertas=abertas,
+                concluidas=concluidas,
+                pendentes_total=pendentes_total,
+                sla_pct=sla_pct,
+                avg_close_h=avg_close_h,
+            )
+        )
+
+    results.sort(key=lambda k: k.pendentes_total, reverse=True)
+    return results
+
+
+def _freeze_filters(filters: Dict[str, Any]) -> Tuple[Tuple[str, Any], ...]:
+    return tuple(sorted(filters.items()))
+
+
+@st.cache_data(ttl=900)
+def _cached_compute(
+    dt_ini: date,
+    dt_fim: date,
+    frozen: Tuple[Tuple[str, Any], ...],
+    _client: ArkmedsClient,
+) -> list[TechKPI]:
+    filters = dict(frozen)
+    return asyncio.run(_async_compute(_client, dt_ini=dt_ini, dt_fim=dt_fim, filters=filters))
+
+
+async def compute_metrics(
+    client: ArkmedsClient, *, dt_ini: date, dt_fim: date, **filters: Any
+) -> list[TechKPI]:
+    frozen = _freeze_filters(filters)
+    return await asyncio.to_thread(_cached_compute, dt_ini, dt_fim, frozen, client)

--- a/tests/test_tech_metrics.py
+++ b/tests/test_tech_metrics.py
@@ -1,0 +1,67 @@
+from datetime import datetime, date
+
+import pytest
+
+from app.services.tech_metrics import compute_metrics, TechKPI
+from app.arkmeds_client.models import OS, OSEstado, User
+
+
+class DummyClient:
+    def __init__(self, os_list):
+        self._os = os_list
+
+    async def list_os(self, **filters):  # noqa: D401 - simple forward
+        return self._os
+
+
+def make_os(id, user, estado, created, closed=None):
+    payload = {
+        "id": id,
+        "tipo_ordem_servico": {"id": 1, "descricao": "P"},
+        "estado": {"id": estado, "descricao": "e"},
+        "responsavel": {"id": user.id, "nome": user.nome, "email": "x"},
+        "data_criacao": created.strftime("%d/%m/%y - %H:%M"),
+        "data_fechamento": closed.strftime("%d/%m/%y - %H:%M") if closed else None,
+    }
+    return OS.model_validate(payload)
+
+
+def make_user(id, nome):
+    return User.model_validate({"id": id, "nome": nome, "email": "x"})
+
+
+@pytest.mark.asyncio
+async def test_compute_tech_metrics():
+    dt_ini = date(2025, 1, 1)
+    dt_fim = date(2025, 1, 31)
+
+    u1 = make_user(1, "Tec1")
+    u2 = make_user(2, "Tec2")
+
+    os_list = [
+        make_os(1, u1, OSEstado.ABERTA.value, datetime(2025, 1, 5)),
+        make_os(2, u1, OSEstado.FECHADA.value, datetime(2025, 1, 2), datetime(2025, 1, 3)),
+        make_os(3, u1, OSEstado.FECHADA.value, datetime(2024, 12, 31), datetime(2025, 1, 5)),
+        make_os(4, u1, OSEstado.ABERTA.value, datetime(2024, 12, 10)),
+        make_os(5, u1, OSEstado.CANCELADA.value, datetime(2025, 1, 10)),
+        make_os(6, u2, OSEstado.ABERTA.value, datetime(2025, 1, 7)),
+        make_os(7, u2, OSEstado.FECHADA.value, datetime(2025, 1, 8), datetime(2025, 1, 9)),
+    ]
+
+    client = DummyClient(os_list)
+    metrics = await compute_metrics(client, dt_ini=dt_ini, dt_fim=dt_fim)
+
+    assert isinstance(metrics, list)
+    assert metrics[0].tecnico_id == 1
+    assert metrics[0].abertas == 1
+    assert metrics[0].concluidas == 2
+    assert metrics[0].pendentes_total == 2
+    assert metrics[0].sla_pct == 50.0
+    assert metrics[0].avg_close_h == 72.0
+
+    assert metrics[1].tecnico_id == 2
+    assert metrics[1].abertas == 1
+    assert metrics[1].concluidas == 1
+    assert metrics[1].pendentes_total == 1
+    assert metrics[1].sla_pct == 100.0
+    assert metrics[1].avg_close_h == 24.0


### PR DESCRIPTION
## Summary
- expand `OSEstado` enum with `CANCELADA`
- add service module `tech_metrics` for technician KPIs
- document how to use technician metrics in README
- test technician KPI calculations

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef9c57c44832ca4f1f47c10328986