### PR TITLE
feat(ui): skeleton multipage app with sidebar

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,6 @@
+[theme]
+primaryColor = "#002d2b"
+backgroundColor = "#ffffff"
+secondaryBackgroundColor = "#f5f8f8"
+textColor = "#000000"
+font = "sans serif"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Projeto para centralizar indicadores da plataforma Arkmeds utilizando Streamlit 
 - Python 3.12+
 - [Poetry](https://python-poetry.org/docs/#installation)
 
-## Como Rodar Localmente
+## Rodando o App
 ```bash
 poetry install
 poetry run streamlit run app/main.py

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,5 @@
 import streamlit as st
+from ui import register_pages
 
-st.title("Dashboard Arkmeds – Em construção")
+st.set_page_config(page_title="Dashboard Arkmeds", layout="wide")
+register_pages()

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,0 +1,24 @@
+import streamlit as st
+
+from .css import inject_global_css
+from .filters import render_filters
+
+PAGES = {
+    "\ud83c\udfe0 Indicadores": "ui/home.py",
+    "\ud83d\udccb Ordens de Servi\u00e7o": "ui/os.py",
+    "\ud83d\udd28 Equipamentos": "ui/equip.py",
+    "\ud83d\udc77 T\u00e9cnicos": "ui/tech.py",
+}
+
+
+def register_pages() -> None:
+    inject_global_css()
+
+    if "filters" not in st.session_state:
+        st.session_state["filters"] = {}
+
+    st.sidebar.title("Menu")
+    for title, path in PAGES.items():
+        st.sidebar.page_link(path, label=title)
+
+    render_filters()

--- a/app/ui/css.py
+++ b/app/ui/css.py
@@ -1,0 +1,13 @@
+import streamlit as st
+
+
+def inject_global_css() -> None:
+    st.markdown(
+        """
+        <style>
+          section[data-testid='stSidebar'] { order:2; border-left:1px solid #eee; }
+          div.block-container             { padding-right:2rem; }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/app/ui/equip.py
+++ b/app/ui/equip.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.header("\ud83d\udd28 Equipamentos \u2013 Em constru\u00e7\u00e3o")

--- a/app/ui/filters.py
+++ b/app/ui/filters.py
@@ -1,0 +1,7 @@
+import streamlit as st
+
+
+def render_filters() -> dict:
+    st.sidebar.date_input("Data in\u00edcio")
+    st.sidebar.date_input("Data fim")
+    return {}

--- a/app/ui/home.py
+++ b/app/ui/home.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.header("\ud83d\udcca Indicadores \u2013 Em constru\u00e7\u00e3o")

--- a/app/ui/os.py
+++ b/app/ui/os.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.header("\ud83d\udccb Ordens de Servi\u00e7o \u2013 Em constru\u00e7\u00e3o")

--- a/app/ui/tech.py
+++ b/app/ui/tech.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.header("\ud83d\udc77 T\u00e9cnicos \u2013 Em constru\u00e7\u00e3o")


### PR DESCRIPTION
## Summary
- add Streamlit multipage skeleton and configure right sidebar
- create placeholder pages and filters component
- add basic theme configuration
- update README with app running steps

## Testing
- `ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687efe21ee44832cb77f84b59fa348a6