### PR TITLE
Add technician ranking page

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,10 @@ Screenshot demonstrando os indicadores e a tabela filtrada.
 Visão geral do parque de equipamentos e métricas de manutenção.
 
 ![Equipamentos](docs/equip_page.png)
+
+## Página de Técnicos
+
+Ranking de desempenho por responsável, com indicadores de pendências,
+concluídas, SLA médio e tempo de fechamento.
+
+![Técnicos](docs/tech_page.png)

--- a/app/ui/tech.py
+++ b/app/ui/tech.py
@@ -1,12 +1,61 @@
+import asyncio
+import statistics
+
+import pandas as pd
+import plotly.express as px
 import streamlit as st
 
-from app.arkmeds_client.auth import ArkmedsAuth
 from app.arkmeds_client.client import ArkmedsClient
+from app.services.tech_metrics import compute_metrics
 
-from .filters import render_filters, show_active_filters
+from .filters import show_active_filters
 
-client = ArkmedsClient(ArkmedsAuth.from_secrets())
-render_filters(client)
-show_active_filters(client)
+filters = st.session_state["filters"]
+version = st.session_state.get("filtros_version", 0)
 
-st.header("\ud83d\udc77 T\u00e9cnicos \u2013 Em constru\u00e7\u00e3o")
+
+@st.cache_data(ttl=900, experimental_allow_widgets=True)
+async def fetch_data(v: int):
+    client = ArkmedsClient.from_session()
+    tech_kpi = await compute_metrics(client, **filters)
+    return tech_kpi
+
+with st.spinner("Calculando KPIs dos técnicos…"):
+    kpis = asyncio.run(fetch_data(version))
+
+show_active_filters(ArkmedsClient.from_session())
+
+total_tecnicos = len(kpis)
+pendentes_totais = sum(t.pendentes_total for t in kpis)
+sla_medio = round(statistics.mean(t.sla_pct for t in kpis), 1) if kpis else 0
+
+cols = st.columns(3)
+cols[0].metric("👷 Técnicos", total_tecnicos)
+cols[1].metric("📦 OS Pendentes", pendentes_totais)
+cols[2].metric("⏱️ SLA médio (%)", sla_medio)
+
+df = pd.DataFrame([t.model_dump() for t in kpis])
+df = df.rename(
+    columns={
+        "abertas": "Abertas (período)",
+        "concluidas": "Concluídas",
+        "pendentes_total": "Pendentes",
+        "sla_pct": "SLA %",
+        "avg_close_h": "Média (h)",
+    }
+)
+
+st.dataframe(df.sort_values("Pendentes", ascending=False), use_container_width=True)
+
+st.download_button("⬇️ CSV", df.to_csv(index=False).encode(), "tecnicos.csv")
+
+df_top = df.nlargest(10, "Pendentes")
+fig = px.bar(
+    df_top,
+    y="nome",
+    x=["Pendentes", "Concluídas"],
+    orientation="h",
+    barmode="stack",
+    labels={"value": "OS", "nome": "Técnico"},
+)
+st.plotly_chart(fig, use_container_width=True)


### PR DESCRIPTION
## Summary
- add full-featured Streamlit page for technician KPIs
- document the new page in the README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffc809a34832ca94b17e1cb5bdd37