### PR TITLE
Add home dashboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ permite detectar mudanças.
 
 ![Filtros](docs/filtros.gif)
 
+## Página Inicial
+
+Visão consolidada dos principais indicadores do mês.
+
+![Home](docs/home_page.png)
+
 ## Página de Ordens de Serviço
 
 Screenshot demonstrando os indicadores e a tabela filtrada.

--- a/app/arkmeds_client/client.py
+++ b/app/arkmeds_client/client.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import date
 from typing import Any, Dict, List, Optional
 
 import httpx
 import streamlit as st
 from aiolimiter import AsyncLimiter
+from dateutil.relativedelta import relativedelta
 
 from .auth import ArkmedsAuth
 from .models import (
@@ -111,3 +113,15 @@ class ArkmedsClient:
     async def list_estados(self, **filters: Any) -> List[EstadoOS]:
         data = await self._get_all_pages("/api/v3/estado_os/", filters)
         return [EstadoOS.model_validate(item) for item in data]
+
+    async def os_monthly_history(self, *, tipo_id: int, months: int = 12) -> List[Dict[str, Any]]:
+        """Return open/closed counts per month.
+
+        Placeholder implementation that returns empty values for each month.
+        """
+        today = date.today().replace(day=1)
+        hist = []
+        for i in range(months - 1, -1, -1):
+            month = today - relativedelta(months=i)
+            hist.append({"mes": month.strftime("%Y-%m"), "abertas": 0, "fechadas": 0})
+        return hist


### PR DESCRIPTION
## Summary
- implement home page with executive KPIs and navigation links
- add placeholder function `os_monthly_history` to client
- include screenshot of the landing page in docs
- document the new page in README

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fff13f1c0832c8856841eb8e65832