### PR TITLE
Add Makefile and helper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ poetry.lock
 # IDE
 .idea/
 .vscode/
+
+scripts/*.pyc
+scripts/*.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PORT ?= 8501
+
+.PHONY: install lint format test run docker compose ci
+
+install:
+poetry install --with dev --no-root
+
+lint:
+poetry run ruff check .
+
+format:
+poetry run ruff format .
+
+test:
+poetry run pytest -q
+
+run:
+poetry run streamlit run app/main.py --server.port $(PORT)
+
+docker:
+docker build -t arkmeds-dashboard .
+
+compose:
+docker compose up --build
+
+ci: lint test

--- a/README.md
+++ b/README.md
@@ -2,154 +2,50 @@
 
 ![CI](https://github.com/<OWNER>/<REPO>/actions/workflows/ci.yml/badge.svg)
 ![CD](https://github.com/<OWNER>/<REPO>/actions/workflows/cd.yml/badge.svg)
+![LOC](https://img.shields.io/tokei/lines/github/<OWNER>/<REPO>)
+![License](https://img.shields.io/github/license/<OWNER>/<REPO>)
 
-## Visão Geral
-Projeto para centralizar indicadores da plataforma Arkmeds utilizando Streamlit multipage.
+![Preview](docs/home_page.png)
 
-## Pré-requisitos
+## Visao Geral
+
+Dashboard multipage em Streamlit para consolidar indicadores da plataforma Arkmeds.
+Reúne ordens de serviço, equipamentos e produtividade em uma interface simples.
+
+## Requisitos
+
 - Python 3.12+
+- Docker
 - [Poetry](https://python-poetry.org/docs/#installation)
 
-## Rodando o App
+## Quick Start
+
 ```bash
-poetry install
-poetry run streamlit run app/main.py
+# configure variáveis locais
+cp .env.example .env
+cp .streamlit/secrets.toml.example .streamlit/secrets.toml
+
+# instalar dependências e subir o app
+make install && make run
 ```
 
-## Estrutura de Pastas
-```
-app/
-├── arkmeds_client/
-├── services/
-├── ui/
-└── main.py
-```
+## Scripts Uteis
 
-## Configuração de secrets
-1. Copie o arquivo de exemplo:
-   ```bash
-   cp .streamlit/secrets.toml.example .streamlit/secrets.toml
-   ```
-2. Preencha as variáveis com suas credenciais reais.
-3. Opcionalmente deixe `token` vazio para que o login seja feito automaticamente.
-
-## Autenticação
-Utilize o `ArkmedsAuth` para obter um JWT de forma transparente.
-
-```python
-from arkmeds_client.auth import ArkmedsAuth
-
-auth = ArkmedsAuth.from_secrets()
-token = await auth.get_token()
-```
-
-## Uso do ArkmedsClient
-
-```python
-from arkmeds_client.auth import ArkmedsAuth
-from arkmeds_client.client import ArkmedsClient
-from arkmeds_client.models import OS
-
-auth = ArkmedsAuth.from_secrets()
-client = ArkmedsClient(auth)
-os = await client.list_os(data_criacao__gte="2025-06-01")
-```
-
-```python
-raw = await client.list_os()[0]
-os_obj: OS = OS.model_validate(raw)
-```
+- `make install` – instala as dependências
+- `make lint` – ruff lint
+- `make format` – ruff format
+- `make test` – pytest
+- `make run` – inicia o Streamlit em localhost:8501
+- `make docker` – build da imagem Docker
+- `make compose` – docker compose up --build
+- `make ci` – executa lint e testes
 
 ## Contribuindo
-1. Instale os hooks do pre-commit dentro do ambiente do Poetry:
-   ```bash
-   poetry shell
-   pre-commit install
-   ```
-2. Para atualizar as versões dos hooks:
-   ```bash
-   pre-commit autoupdate
-   ```
 
-## KPIs de OS
+1. Crie uma branch a partir de `main`.
+2. Commits descritivos e mensagens no imperativo.
+3. Abra um Pull Request para revisao.
 
-```python
-from app.services.os_metrics import compute_metrics
-from app.arkmeds_client.auth import ArkmedsAuth
-from app.arkmeds_client.client import ArkmedsClient
-from datetime import date
+## Contato / Licenca
 
-auth = ArkmedsAuth.from_secrets()
-client = ArkmedsClient(auth)
-metrics = await compute_metrics(client, dt_ini=date(2025, 1, 1), dt_fim=date(2025, 1, 31))
-print(metrics)
-```
-
-## KPIs de Equipamentos
-
-```python
-from app.services.equip_metrics import compute_metrics
-from app.arkmeds_client.auth import ArkmedsAuth
-from app.arkmeds_client.client import ArkmedsClient
-from datetime import date
-
-auth = ArkmedsAuth.from_secrets()
-client = ArkmedsClient(auth)
-metrics = await compute_metrics(client, dt_ini=date(2025, 1, 1), dt_fim=date(2025, 1, 31))
-print(metrics)
-```
-
-## KPIs de Técnicos
-
-```python
-from app.services.tech_metrics import compute_metrics
-from app.arkmeds_client.auth import ArkmedsAuth
-from app.arkmeds_client.client import ArkmedsClient
-from datetime import date
-
-auth = ArkmedsAuth.from_secrets()
-client = ArkmedsClient(auth)
-metrics = await compute_metrics(client, dt_ini=date(2025, 1, 1), dt_fim=date(2025, 1, 31))
-print(metrics)
-```
-
-## Filtros Globais
-
-Componente reutilizável para seleção de datas e opções na sidebar. O estado é
-preservado em `st.session_state["filters"]` e um contador `filtros_version`
-permite detectar mudanças.
-
-![Filtros](docs/filtros.gif)
-
-## Página Inicial
-
-Visão consolidada dos principais indicadores do mês.
-
-![Home](docs/home_page.png)
-
-## Página de Ordens de Serviço
-
-Screenshot demonstrando os indicadores e a tabela filtrada.
-
-![Ordens de Serviço](docs/os_page.png)
-
-## Página de Equipamentos
-
-Visão geral do parque de equipamentos e métricas de manutenção.
-
-![Equipamentos](docs/equip_page.png)
-
-## Página de Técnicos
-
-Ranking de desempenho por responsável, com indicadores de pendências,
-concluídas, SLA médio e tempo de fechamento.
-
-![Técnicos](docs/tech_page.png)
-
-## Docker Multi-Arch
-
-Para gerar a imagem para arm64 e amd64 utilize:
-```bash
-docker buildx build --platform linux/amd64,linux/arm64 -t rafael/arkmeds-dashboard:latest .
-```
-
+Projeto sob a [MIT License](LICENSE). Dúvidas abra uma issue.

--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -1,0 +1,2 @@
+poetry install --with dev --no-root
+poetry run streamlit run app/main.py @Args

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+poetry install --with dev --no-root
+poetry run streamlit run app/main.py "$@"


### PR DESCRIPTION
## Summary
- simplify README with quick start and usage docs
- add Makefile to standardize commands
- add bash and PowerShell helper scripts
- update .gitignore

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68801586b6d0832c8ebeea4907691c5c