### PR TITLE
Fix windows emoji crash

### DIFF
--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -6,3 +6,4 @@ token ="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InJhZmFlbC5yaWJlaXJ
 [app]
 cache_ttl = 900 # segundos
 max_retries = 3
+allow_emoji = true

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -7,3 +7,5 @@ token = "JWT_AQUI (opcional – será gerado se vazio)"
 [app]
 cache_ttl = 900 # segundos
 max_retries = 3
+allow_emoji = true
+

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ make install && make run
 - `make compose` – docker compose up --build
 - `make ci` – executa lint e testes
 
+## Problemas comuns
+
+Em algumas versões antigas do Windows a renderização de emojis pode disparar
+`UnicodeEncodeError` ao iniciar o Streamlit. O dashboard tenta detectar esse
+cenário e remove os ícones automaticamente. Se preferir desativar os emojis em
+qualquer plataforma, ajuste o arquivo `.streamlit/secrets.toml`:
+
+```toml
+[app]
+allow_emoji = false
+```
+
 ## Contribuindo
 
 1. Crie uma branch a partir de `main`.

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -3,6 +3,7 @@ from datetime import date
 import streamlit as st
 
 from .css import inject_global_css
+from .utils import safe_label
 
 PAGES = {
     "\ud83c\udfe0 Indicadores": "ui/home.py",
@@ -27,5 +28,5 @@ def register_pages() -> None:
 
     st.sidebar.title("Menu")
     for title, path in PAGES.items():
-        st.sidebar.page_link(path, label=title)
+        st.sidebar.page_link(path, label=safe_label(title))
 

--- a/app/ui/utils.py
+++ b/app/ui/utils.py
@@ -1,0 +1,17 @@
+import sys
+import streamlit as st
+
+EMOJI_OK = (
+    sys.platform != "win32" or getattr(sys, "getwindowsversion", lambda: None)().build >= 9200
+    if hasattr(sys, "getwindowsversion")
+    else True
+)
+
+
+def safe_label(label: str) -> str:
+    allow = st.secrets.get("app", {}).get("allow_emoji", True)
+    if allow and EMOJI_OK:
+        return label
+    return (
+        label.encode("utf-16", "surrogatepass").decode("utf-16").encode("ascii", "ignore").decode()
+    )

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,0 +1,19 @@
+import importlib
+import types
+import sys
+import streamlit as st
+
+
+def test_safe_label_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "getwindowsversion",
+        lambda: types.SimpleNamespace(build=1000),
+        raising=False,
+    )
+    mod = importlib.import_module("app.ui.utils")
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "st", types.SimpleNamespace(secrets={"app": {"allow_emoji": True}}))
+    assert mod.safe_label("🏠 Home") == " Home"
+


### PR DESCRIPTION
## Summary
- add `safe_label` helper to strip emojis on older Windows
- support emoji disable via `[app] allow_emoji` in secrets
- update page registration to use safe labels
- document emoji workaround
- cover behaviour with new unit test

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801dcc00b4832cae83c8824e0447f6