### PR TITLE
Fix ruff config

### DIFF
--- a/app/ui/utils.py
+++ b/app/ui/utils.py
@@ -1,4 +1,5 @@
 import sys
+
 import streamlit as st
 
 EMOJI_OK = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,14 @@ pytest-asyncio = "^1.1.0"
 respx = "^0.22.0"
 pytest-cov = "^6.2"
 
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100
-extend-select = ["I"]
 exclude = ["tests/**"]
+
+[tool.ruff.lint]
+extend-select = ["I"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary
- automatically sort imports in `utils.py`
- move ruff linter options into `[tool.ruff.lint]`

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688020b2bb00832c962f0b1d5c6fa86d