### PR TITLE
Fix emoji surrogate handling on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Em algumas versões antigas do Windows a renderização de emojis pode disparar
 cenário e remove os ícones automaticamente. Se preferir desativar os emojis em
 qualquer plataforma defina a variável de ambiente `ALLOW_EMOJI=0` (no
 PowerShell: `setx ALLOW_EMOJI 0`).
+Defina `setx ALLOW_EMOJI 0` para forçar remoção de emoji em qualquer SO.
 
 ## Contribuindo
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import streamlit as st
+
 from ui import register_pages
 
 st.set_page_config(page_title="Dashboard Arkmeds", layout="wide")

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -2,8 +2,9 @@ from datetime import date
 
 import streamlit as st
 
-from .css import inject_global_css
 from ui.utils import safe_label
+
+from .css import inject_global_css
 
 PAGES = {
     "\ud83c\udfe0 Indicadores": "ui/home.py",

--- a/app/ui/utils.py
+++ b/app/ui/utils.py
@@ -1,11 +1,15 @@
 import os
 import sys
-import unicodedata
 
-EMOJI_ALLOWED = False if os.name == "nt" and sys.maxunicode == 0xFFFF else True
+
+def _strip_surrogates(text: str) -> str:
+    """Remove qualquer UTF-16 surrogate pair individual ou já combinado."""
+    return "".join(c for c in text if ord(c) < 0x10000)
 
 
 def safe_label(label: str) -> str:
-    if EMOJI_ALLOWED and os.getenv("ALLOW_EMOJI", "1") == "1":
+    """Remove emojis/caracteres fora do BMP em ambientes que não suportam."""
+    allow = os.getenv("ALLOW_EMOJI", "1") == "1"
+    if allow and sys.maxunicode >= 0x10FFFF and os.name != "nt":
         return label
-    return "".join(c for c in label if unicodedata.category(c) != "So")
+    return _strip_surrogates(label)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,3 +9,11 @@ def test_safe_label_windows(monkeypatch):
     mod = importlib.import_module("app.ui.utils")
     importlib.reload(mod)
     assert mod.safe_label("🏠 Home") == " Home"
+
+
+def test_strip_surrogates(monkeypatch):
+    monkeypatch.setenv("ALLOW_EMOJI", "0")
+    from ui.utils import safe_label
+    raw = "🏠 Home"
+    cleaned = safe_label(raw)
+    assert cleaned.strip() == "Home"

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,4 +1,4 @@
-from importlib import import_module
 import sys
+from importlib import import_module
 
 sys.modules[__name__] = import_module('app.ui')


### PR DESCRIPTION
## Summary
- sanitize emojis by removing BMP-surrogate characters
- add a unit test for surrogate stripping
- add note about `ALLOW_EMOJI` in README
- keep imports sorted for linting

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802a1c1c68832cac3705a7247b3cbb