### PR TITLE
Fix test encoding issue on Windows

### DIFF
--- a/tests/e2e/test_equip_page.py
+++ b/tests/e2e/test_equip_page.py
@@ -8,7 +8,7 @@ import pytest
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, ROOT)
 
-with open(os.path.join(ROOT, "app", "ui", "equip.py")) as f:
+with open(os.path.join(ROOT, "app", "ui", "equip.py"), encoding="utf-8") as f:
     src = f.read()
 start = src.index("def _build_history_df")
 end = src.index("@st.cache_data")


### PR DESCRIPTION
## Summary
- open equip UI file with explicit UTF-8 encoding to avoid Windows decode error

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802d7b144c832c88790fa5ac854183