### PR TITLE
Fix Windows emoji sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cenário e remove os ícones automaticamente. Se preferir desativar os emojis em
 qualquer plataforma defina a variável de ambiente `ALLOW_EMOJI=0` (no
 PowerShell: `setx ALLOW_EMOJI 0`).
 Defina `setx ALLOW_EMOJI 0` para forçar remoção de emoji em qualquer SO.
+Se ainda ver erro `UnicodeEncodeError`, defina `setx ALLOW_EMOJI 0` e reinicie terminal.
 
 ## Contribuindo
 

--- a/app/ui/utils.py
+++ b/app/ui/utils.py
@@ -1,15 +1,25 @@
 import os
+import re
 import sys
+import unicodedata
+
+_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
 
 
-def _strip_surrogates(text: str) -> str:
-    """Remove qualquer UTF-16 surrogate pair individual ou já combinado."""
-    return "".join(c for c in text if ord(c) < 0x10000)
+def is_windows_narrow() -> bool:
+    return os.name == "nt" and sys.maxunicode == 0xFFFF
 
 
-def safe_label(label: str) -> str:
-    """Remove emojis/caracteres fora do BMP em ambientes que não suportam."""
-    allow = os.getenv("ALLOW_EMOJI", "1") == "1"
-    if allow and sys.maxunicode >= 0x10FFFF and os.name != "nt":
-        return label
-    return _strip_surrogates(label)
+def strip_emojis(text: str) -> str:
+    # remove surrogates + symbols/emoji categories (So & Sk)
+    no_surr = _SURROGATE_RE.sub("", text)
+    return "".join(
+        ch for ch in no_surr if unicodedata.category(ch) not in ("So", "Sk")
+    )
+
+
+def safe_label(text: str) -> str:
+    """Return label safe for Streamlit on Windows narrow builds."""
+    if os.getenv("ALLOW_EMOJI", "1") == "0" or is_windows_narrow():
+        return strip_emojis(text)
+    return text

--- a/tests/test_safe_label.py
+++ b/tests/test_safe_label.py
@@ -1,0 +1,11 @@
+from ui.utils import safe_label, is_windows_narrow
+
+
+def test_safe_label_removes_surrogates(monkeypatch):
+    win_narrow_mock = True
+    label = "🏠 Home"  # U+1F3E0
+    if win_narrow_mock:
+        monkeypatch.setenv("ALLOW_EMOJI", "0")
+    cleaned = safe_label(label) if win_narrow_mock else label
+    assert "🏠" not in cleaned
+    assert cleaned.strip() == "Home"


### PR DESCRIPTION
## Summary
- sanitize emojis thoroughly via `safe_label`
- test emoji stripping
- document troubleshooting for `UnicodeEncodeError`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802f6ed4a4832cbc5f8a0b5ecad2a9