### PR TITLE
Fix emoji handling on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 
 Em algumas versões antigas do Windows a renderização de emojis pode disparar
 `UnicodeEncodeError` ao iniciar o Streamlit. O dashboard tenta detectar esse
-cenário e remove os ícones automaticamente. Se preferir desativar os emojis em
-qualquer plataforma defina a variável de ambiente `ALLOW_EMOJI=0` (no
-PowerShell: `setx ALLOW_EMOJI 0`).
-Defina `setx ALLOW_EMOJI 0` para forçar remoção de emoji em qualquer SO.
-Se ainda ver erro `UnicodeEncodeError`, defina `setx ALLOW_EMOJI 0` e reinicie terminal.
+cenário e remove os ícones automaticamente.
+Se preferir desativar os emojis em qualquer plataforma defina a variável de
+ambiente `ALLOW_EMOJI=0` (no Windows execute `setx ALLOW_EMOJI 0`).
+Se ainda ver o erro, force a remoção de emojis reiniciando o terminal após
+definir `ALLOW_EMOJI=0`.
 
 ## Contribuindo
 

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -2,6 +2,8 @@ from datetime import date
 
 import streamlit as st
 
+from ui.utils import safe_label
+
 from .css import inject_global_css
 
 PAGES = {
@@ -27,4 +29,4 @@ def register_pages() -> None:
 
     st.sidebar.title("Menu")
     for title, path in PAGES.items():
-        st.sidebar.page_link(path, label=title)
+        st.sidebar.page_link(path, label=safe_label(title))

--- a/app/ui/utils.py
+++ b/app/ui/utils.py
@@ -1,0 +1,22 @@
+import os
+import re
+import sys
+import unicodedata
+
+_SURR = re.compile(r"[\ud800-\udfff]")
+
+
+def _strip(text: str) -> str:
+    no_surr = _SURR.sub("", text)
+    return "".join(
+        ch for ch in no_surr if unicodedata.category(ch) not in ("So", "Sk")
+    )
+
+
+def safe_label(text: str) -> str:
+    """Retorna label seguro em builds Windows narrow; respeita env ALLOW_EMOJI."""
+    if os.getenv("ALLOW_EMOJI", "1") == "0" or (
+        os.name == "nt" and sys.maxunicode == 0xFFFF
+    ):
+        return _strip(text)
+    return text

--- a/tests/test_safe_label.py
+++ b/tests/test_safe_label.py
@@ -1,11 +1,7 @@
-from ui.utils import safe_label, is_windows_narrow
+from ui.utils import safe_label
 
 
-def test_safe_label_removes_surrogates(monkeypatch):
-    win_narrow_mock = True
-    label = "🏠 Home"  # U+1F3E0
-    if win_narrow_mock:
-        monkeypatch.setenv("ALLOW_EMOJI", "0")
-    cleaned = safe_label(label) if win_narrow_mock else label
-    assert "🏠" not in cleaned
-    assert cleaned.strip() == "Home"
+def test_safe_label_strips_emoji(monkeypatch):
+    monkeypatch.setenv("ALLOW_EMOJI", "0")
+    assert safe_label("🏠 Home")[0] != "🏠"
+    assert safe_label("🏠 Home").strip() == "Home"


### PR DESCRIPTION
## Summary
- add `safe_label` utility to filter emoji on narrow Windows builds
- apply `safe_label` when registering sidebar pages
- document `ALLOW_EMOJI` workaround
- add regression test for `safe_label`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804d83f858832caffebd03e100ee69