### PR TITLE
Issue 8.8 fix safe_label kill switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
         run: |
           pip install --upgrade pip poetry
           poetry install --with dev --no-root
-      - name: CI via PowerShell
-        shell: pwsh
-        run: ./make.ps1 -Target ci
+      - name: Ruff Lint
+        run: poetry run ruff check .
+      - name: Pytest
+        run: poetry run pytest -q
       

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ ambiente `ALLOW_EMOJI=0` (no Windows execute `setx ALLOW_EMOJI 0`).
 Se ainda ver o erro, force a remoção de emojis reiniciando o terminal após
 definir `ALLOW_EMOJI=0`.
 
+## Emoji opt-in
+
+Para ativar os emojis mesmo em plataformas que podem falhar:
+
+```powershell
+$env:ALLOW_EMOJI=1
+streamlit run app/main.py --allow-unsafe-emoji
+```
+
 ## Contribuindo
 
 1. Crie uma branch a partir de `main`.

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import streamlit as st
+
 from ui import register_pages
 
 st.set_page_config(page_title="Dashboard Arkmeds", layout="wide")

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -29,4 +29,6 @@ def register_pages() -> None:
 
     st.sidebar.title("Menu")
     for title, path in PAGES.items():
-        st.sidebar.page_link(path, label=safe_label(title))
+        label = safe_label(title)
+        path = safe_label(path)
+        st.sidebar.page_link(path, label=label)

--- a/app/ui/utils.py
+++ b/app/ui/utils.py
@@ -4,19 +4,20 @@ import sys
 import unicodedata
 
 _SURR = re.compile(r"[\ud800-\udfff]")
+_NONBMP = re.compile(r"[\U00010000-\U0010ffff]")
 
 
 def _strip(text: str) -> str:
-    no_surr = _SURR.sub("", text)
-    return "".join(
-        ch for ch in no_surr if unicodedata.category(ch) not in ("So", "Sk")
-    )
+    txt = _SURR.sub("", text)
+    txt = _NONBMP.sub("", txt)
+    return "".join(c for c in txt if unicodedata.category(c) not in ("So", "Sk"))
+
+
+def emoji_allowed() -> bool:
+    cli_flag = "--allow-unsafe-emoji" in sys.argv
+    env_flag = os.getenv("ALLOW_EMOJI", "0") == "1"
+    return cli_flag and env_flag
 
 
 def safe_label(text: str) -> str:
-    """Retorna label seguro em builds Windows narrow; respeita env ALLOW_EMOJI."""
-    if os.getenv("ALLOW_EMOJI", "1") == "0" or (
-        os.name == "nt" and sys.maxunicode == 0xFFFF
-    ):
-        return _strip(text)
-    return text
+    return text if emoji_allowed() else _strip(text)

--- a/tests/test_safe_label.py
+++ b/tests/test_safe_label.py
@@ -5,3 +5,9 @@ def test_safe_label_strips_emoji(monkeypatch):
     monkeypatch.setenv("ALLOW_EMOJI", "0")
     assert safe_label("🏠 Home")[0] != "🏠"
     assert safe_label("🏠 Home").strip() == "Home"
+
+
+def test_safe_label_removes_all_nonbmp(monkeypatch):
+    monkeypatch.setenv("ALLOW_EMOJI", "0")
+    emo = "📑 Ordens"
+    assert safe_label(emo).lstrip().startswith("Ordens")


### PR DESCRIPTION
## Summary
- hard strip non-BMP characters in `safe_label`
- apply label sanitation when registering pages
- document emoji opt-in steps
- ensure Windows CI runs tests

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688052642a08832cb4c16bd31481a60c