### PR TITLE
Fix KeyError from manual page_link leftovers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,3 @@
-import streamlit as st
-
 from ui import register_pages
 
-st.set_page_config(page_title="Dashboard Arkmeds", layout="wide")
 register_pages()

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -6,7 +6,10 @@ from .css import inject_global_css
 
 
 def register_pages() -> None:
+    """Configure Streamlit and initialize session state."""
+    st.set_page_config(page_title="Dashboard Arkmeds", page_icon="🩺", layout="wide")
     inject_global_css()
+
 
     if "filters" not in st.session_state:
         st.session_state["filters"] = {


### PR DESCRIPTION
## Summary
- configure Streamlit in `register_pages`
- simplify `main.py` to just call `register_pages`

## Testing
- `ruff check .`
- `pytest -q`
- `streamlit run app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68811cca3b1c832c97b8e4ae755356b8