### PR TITLE
Fix import path by installing app as editable package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install deps
         run: |
           pip install --upgrade pip poetry
-          poetry install --with dev --no-root
+          make install
       - name: Ruff Lint
         run: poetry run ruff check .
       - name: Pytest
@@ -38,7 +38,7 @@ jobs:
       - name: Install deps
         run: |
           pip install --upgrade pip poetry
-          poetry install --with dev --no-root
+          make install
       - name: Ruff Lint
         run: poetry run ruff check .
       - name: Pytest

--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,24 @@ PORT ?= 8501
 .PHONY: install lint format test run docker compose ci
 
 install:
-poetry install --with dev --no-root
+	poetry install --with dev --no-root && poetry run pip install -e .
 
 lint:
-poetry run ruff check .
+	poetry run ruff check .
 
 format:
-poetry run ruff format .
+	poetry run ruff format .
 
 test:
-poetry run pytest -q
+	poetry run pytest -q
 
 run:
-poetry run streamlit run app/main.py --server.port $(PORT)
+	poetry run streamlit run app/main.py --server.port $(PORT)
 
 docker:
-docker build -t arkmeds-dashboard .
+	docker build -t arkmeds-dashboard .
 
 compose:
-docker compose up --build
+	docker compose up --build
 
 ci: lint test

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make install && make run
 ./make.bat install
 ./make.bat run PORT=8501
 # ou em PowerShell puro
-./make.ps1 -Target install
+./make.ps1 -Target install   # instala dependências + package editável
 ./make.ps1 -Target run -Port 8501
 # se bloquear scripts, use
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,10 @@
-from ui import register_pages
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).parent
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from ui import register_pages  # noqa: E402
 
 register_pages()

--- a/make.bat
+++ b/make.bat
@@ -3,7 +3,7 @@ setlocal EnableDelayedExpansion
 REM Porta padrão pode ser sobreposta com PORT=xxxx
 if "%PORT%"=="" set PORT=8501
 REM ---- TARGETS -------------------------------------------------
-if "%1"=="install" (poetry install --with dev --no-root & goto :eof)
+if "%1"=="install" (poetry install --with dev --no-root && poetry run pip install -e . & goto :eof)
 if "%1"=="run" (poetry run streamlit run app/main.py --server.port !PORT! & goto :eof)
 if "%1"=="lint" (poetry run ruff check . & goto :eof)
 if "%1"=="format" (poetry run ruff format . & goto :eof)

--- a/make.ps1
+++ b/make.ps1
@@ -1,7 +1,7 @@
 Param([string]$Target="help", [int]$Port=8501)
 function Run($cmd){ Write-Host "> $cmd"; iex $cmd }
 switch ($Target) {
-    "install" { Run "poetry install --with dev --no-root" }
+    "install" { Run "poetry install --with dev --no-root && poetry run pip install -e ." }
     "run" { Run "poetry run streamlit run app/main.py --server.port $Port" }
     "lint" { Run "poetry run ruff check ." }
     "format" { Run "poetry run ruff format ." }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.poetry]
-package-mode = false
+package-mode = true
+packages = [ { include = "app" } ]
 
 [project]
 name = "indicadores-comg"


### PR DESCRIPTION
## Summary
- install `app` package in editable mode
- ensure project root is on `PYTHONPATH` at runtime
- update install scripts for Linux, Windows and CI
- tweak README quick-start instructions

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688120c35df0832cb06e6a5ff5147515