### PR TITLE
Fix imports in Streamlit pages

### DIFF
--- a/app/pages/1_home.py
+++ b/app/pages/1_home.py
@@ -1,7 +1,7 @@
 import streamlit as st
+from arkmeds_client.auth import ArkmedsAuth
+from arkmeds_client.client import ArkmedsClient
 
-from app.arkmeds_client.auth import ArkmedsAuth
-from app.arkmeds_client.client import ArkmedsClient
 from app.ui.filters import render_filters, show_active_filters
 
 st.set_page_config(page_title="Indicadores", page_icon="🏠")

--- a/app/pages/2_os.py
+++ b/app/pages/2_os.py
@@ -2,8 +2,8 @@ import asyncio
 
 import pandas as pd
 import streamlit as st
+from arkmeds_client.client import ArkmedsClient
 
-from app.arkmeds_client.client import ArkmedsClient
 from app.services.os_metrics import compute_metrics
 from app.ui.filters import show_active_filters
 

--- a/app/pages/3_equip.py
+++ b/app/pages/3_equip.py
@@ -6,10 +6,10 @@ from statistics import mean
 import pandas as pd
 import plotly.express as px
 import streamlit as st
+from arkmeds_client.client import ArkmedsClient
+from arkmeds_client.models import OS
 from dateutil.relativedelta import relativedelta
 
-from app.arkmeds_client.client import ArkmedsClient
-from app.arkmeds_client.models import OS
 from app.config.os_types import TIPO_CORRETIVA
 from app.services.equip_metrics import compute_metrics
 from app.ui.filters import show_active_filters

--- a/app/pages/4_tech.py
+++ b/app/pages/4_tech.py
@@ -1,7 +1,7 @@
 import streamlit as st
+from arkmeds_client.auth import ArkmedsAuth
+from arkmeds_client.client import ArkmedsClient
 
-from app.arkmeds_client.auth import ArkmedsAuth
-from app.arkmeds_client.client import ArkmedsClient
 from app.ui.filters import render_filters, show_active_filters
 
 st.set_page_config(page_title="Técnicos", page_icon="👷")

--- a/app/services/equip_metrics.py
+++ b/app/services/equip_metrics.py
@@ -8,11 +8,11 @@ from typing import Any, Dict, Tuple
 
 import httpx
 import streamlit as st
+from arkmeds_client.auth import ArkmedsAuthError
+from arkmeds_client.client import ArkmedsClient
+from arkmeds_client.models import OSEstado
 from pydantic import BaseModel
 
-from app.arkmeds_client.auth import ArkmedsAuthError
-from app.arkmeds_client.client import ArkmedsClient
-from app.arkmeds_client.models import OSEstado
 from app.config.os_types import TIPO_CORRETIVA
 
 

--- a/app/services/os_metrics.py
+++ b/app/services/os_metrics.py
@@ -7,11 +7,11 @@ from typing import Any, Tuple
 
 import httpx
 import streamlit as st
+from arkmeds_client.auth import ArkmedsAuthError
+from arkmeds_client.client import ArkmedsClient
+from arkmeds_client.models import OSEstado
 from pydantic import BaseModel
 
-from app.arkmeds_client.auth import ArkmedsAuthError
-from app.arkmeds_client.client import ArkmedsClient
-from app.arkmeds_client.models import OSEstado
 from app.config.os_types import (
     AREA_ENG_CLIN,
     AREA_PREDIAL,

--- a/app/services/tech_metrics.py
+++ b/app/services/tech_metrics.py
@@ -8,11 +8,10 @@ from typing import Any, Dict, Tuple
 
 import httpx
 import streamlit as st
+from arkmeds_client.auth import ArkmedsAuthError
+from arkmeds_client.client import ArkmedsClient
+from arkmeds_client.models import OSEstado
 from pydantic import BaseModel
-
-from app.arkmeds_client.auth import ArkmedsAuthError
-from app.arkmeds_client.client import ArkmedsClient
-from app.arkmeds_client.models import OSEstado
 
 SLA_HOURS = int(os.getenv("OS_SLA_HOURS", 72))
 

--- a/app/ui/filters.py
+++ b/app/ui/filters.py
@@ -6,9 +6,8 @@ from datetime import date
 from typing import List
 
 import streamlit as st
-
-from app.arkmeds_client.client import ArkmedsClient
-from app.arkmeds_client.models import EstadoOS, TipoOS, User
+from arkmeds_client.client import ArkmedsClient
+from arkmeds_client.models import EstadoOS, TipoOS, User
 
 
 @st.cache_data(ttl=86400)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Ensure app directory is on sys.path so modules can be imported without the
+# `app.` prefix when running tests from the repository root.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))


### PR DESCRIPTION
## Summary
- use `arkmeds_client` directly in Streamlit pages
- update service and UI imports to drop the `app.` prefix
- add test `conftest` to ensure `app` is on `sys.path`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881267ae070832caa0d06d758be8893