### PR TITLE
Fix Arkmeds login URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cp .streamlit/secrets.toml.example .streamlit/secrets.toml
 # Exemplo:
 # [arkmeds]
 # base_url = "https://comg.arkmeds.com"
+# O endpoint de login utilizado pela API 
+# "/api/v3/auth/login" não possui barra final.
 
 # instalar dependências e subir o app (Linux/macOS)
 make install && make run

--- a/app/arkmeds_client/auth.py
+++ b/app/arkmeds_client/auth.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import httpx
 import streamlit as st
-from dateutil import parser
 
 from .models import TokenData
 
@@ -45,7 +44,7 @@ class ArkmedsAuth:
         for attempt in range(self.max_tries):
             try:
                 resp = await client.post(
-                    "/rest-auth/token-auth/",
+                    "/api/v3/auth/login",
                     json={"email": self.email, "password": self.password},
                     timeout=10,
                 )
@@ -54,7 +53,6 @@ class ArkmedsAuth:
                 resp.raise_for_status()
                 data = resp.json()
                 token = data.get("token") or data.get("access")
-                # O endpoint /rest-auth/token-auth/ retorna apenas o token JWT, sem expiração explícita
                 if token is None:
                     raise ArkmedsAuthError("Malformed login response")
                 # Define expiração padrão de 1 hora se não vier no payload

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,63 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import httpx
+from httpx import Response, Request, MockTransport
+
+from app.arkmeds_client.auth import ArkmedsAuth, ArkmedsAuthError, TokenData
+
+
+class DummyAuth(ArkmedsAuth):
+    """ArkmedsAuth with custom transport for testing."""
+
+    def __init__(self, transport: MockTransport) -> None:
+        super().__init__(email="a", password="b", base_url="https://api.test")
+        self._client = httpx.AsyncClient(base_url=self.base_url, transport=transport)
+
+
+@pytest.mark.asyncio
+async def test_login_success_without_trailing_slash():
+    async def handler(request: Request) -> Response:
+        if request.url.path == "/api/v3/auth/login":
+            return Response(
+                200,
+                json={"token": "x"},
+            )
+        return Response(404)
+
+    auth = DummyAuth(MockTransport(handler))
+    data = await auth.login()
+    assert isinstance(data, TokenData)
+    assert data.token == "x"
+
+
+class OldAuth(ArkmedsAuth):
+    async def login(self) -> TokenData:  # type: ignore[override]
+        client = await self._get_client()
+        resp = await client.post(
+            "/api/v3/auth/login/",
+            json={"email": self.email, "password": self.password},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        exp = datetime.now(timezone.utc) + timedelta(hours=1)
+        token = resp.json().get("token")
+        if not token:
+            raise ArkmedsAuthError("Malformed login response")
+        self._token = TokenData(token=token, exp=exp)
+        return self._token
+
+
+@pytest.mark.asyncio
+async def test_login_with_trailing_slash_returns_404():
+    async def handler(request: Request) -> Response:
+        assert request.url.path == "/api/v3/auth/login/"
+        return Response(404)
+
+    auth = OldAuth(email="a", password="b", base_url="https://api.test")
+    auth._client = httpx.AsyncClient(base_url=auth.base_url, transport=MockTransport(handler))
+    with pytest.raises(httpx.HTTPStatusError):
+        await auth.login()
+
+


### PR DESCRIPTION
## Summary
- fix login endpoint path for Arkmeds API
- document login URL in README
- test login behavior with and without trailing slash

## Testing
- `ruff check .`
- `pytest -q`
- `timeout 5 make run`

------
https://chatgpt.com/codex/tasks/task_e_68814813fc68832cb54e919232d76b67