### PR TITLE
Handle Arkmeds token via secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ cp .streamlit/secrets.toml.example .streamlit/secrets.toml
 # Exemplo:
 # [arkmeds]
 # base_url = "https://comg.arkmeds.com"
-# O endpoint de login utilizado pela API 
+# se já possuir um JWT válido, defina `token` para evitar login
+# O endpoint de login utilizado pela API
 # "/api/v3/auth/login" não possui barra final.
 
 # instalar dependências e subir o app (Linux/macOS)


### PR DESCRIPTION
## Summary
- allow passing a JWT to `ArkmedsAuth` to skip login requests
- document optional token in README

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68815473f27c832ca949b76a946b31c3