### PR TITLE
Fix duplicate estado_ids filter

### DIFF
--- a/app/services/equip_metrics.py
+++ b/app/services/equip_metrics.py
@@ -36,6 +36,30 @@ class EquipmentMetrics:
     mttr_hours: float
     mtbf_hours: float
 
+    # Compatibility aliases
+    @property
+    def ativos(self) -> int:
+        return self.active
+
+    @property
+    def desativados(self) -> int:
+        return self.inactive
+
+    @property
+    def em_manutencao(self) -> int:
+        return self.in_maintenance
+
+    @property
+    def mttr_h(self) -> float:
+        return self.mttr_hours
+
+    @property
+    def mtbf_h(self) -> float:
+        return self.mtbf_hours
+
+# Backwards compatibility alias
+EquipMetrics = EquipmentMetrics
+
 
 async def fetch_equipment_data(
     client: ArkmedsClient, 
@@ -170,10 +194,12 @@ async def _async_compute_metrics(
 
 
 async def compute_metrics(
-    client: ArkmedsClient, 
+    client: ArkmedsClient,
     *,
-    start_date: date, 
-    end_date: date, 
+    start_date: date | None = None,
+    end_date: date | None = None,
+    dt_ini: date | None = None,
+    dt_fim: date | None = None,
     **filters: Any
 ) -> EquipmentMetrics:
     """Public interface to compute equipment metrics.
@@ -190,11 +216,13 @@ async def compute_metrics(
     Returns:
         EquipmentMetrics object containing all computed metrics
     """
+    start_date = start_date or dt_ini
+    end_date = end_date or dt_fim
     frozen = tuple(sorted(filters.items()))
     return await asyncio.to_thread(
-        _cached_compute, 
-        start_date, 
-        end_date, 
-        frozen, 
+        _cached_compute,
+        start_date,
+        end_date,
+        frozen,
         client
     )

--- a/app/services/tech_metrics.py
+++ b/app/services/tech_metrics.py
@@ -38,6 +38,34 @@ class TechnicianKPI:
     sla_percentage: float
     average_close_hours: float
 
+    # Compatibility alias
+    @property
+    def tecnico_id(self) -> int:
+        return self.technician_id
+
+    @property
+    def abertas(self) -> int:
+        return self.open_orders
+
+    @property
+    def concluidas(self) -> int:
+        return self.completed_orders
+
+    @property
+    def pendentes_total(self) -> int:
+        return self.total_pending
+
+    @property
+    def sla_pct(self) -> float:
+        return self.sla_percentage
+
+    @property
+    def avg_close_h(self) -> float:
+        return self.average_close_hours
+
+# Backwards compatibility alias
+TechKPI = TechnicianKPI
+
 
 async def fetch_technician_orders(
     client: ArkmedsClient,
@@ -199,8 +227,10 @@ async def _async_compute_metrics(
 async def compute_metrics(
     client: ArkmedsClient,
     *,
-    start_date: date,
-    end_date: date,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    dt_ini: date | None = None,
+    dt_fim: date | None = None,
     **filters: Any
 ) -> list[TechnicianKPI]:
     """Public interface to compute technician metrics.
@@ -217,6 +247,8 @@ async def compute_metrics(
     Returns:
         List of TechnicianKPI objects containing metrics for each technician
     """
+    start_date = start_date or dt_ini
+    end_date = end_date or dt_fim
     frozen = tuple(sorted(filters.items()))
     return await asyncio.to_thread(
         _cached_compute,


### PR DESCRIPTION
## Summary
- sanitize filter params when fetching service orders
- alias metric dataclasses with Portuguese property names for compatibility
- support `dt_ini` and `dt_fim` in compute_metrics APIs
- add regression test for OS metrics with estado filter

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6881734664d0832cbeb2bacdc8928ed8